### PR TITLE
Fix deprecation of int(x) in Julia 0.4

### DIFF
--- a/src/LibExpat.jl
+++ b/src/LibExpat.jl
@@ -163,7 +163,7 @@ cb_end_cdata = cfunction(end_cdata, Void, (Ptr{Void},))
 function cdata (p_xph::Ptr{Void}, s::Ptr{Uint8}, len::Cint)
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
 
-    txt = bytestring(s, int(len))
+    txt = bytestring(s, @compat(Int(len)))
     push!(xph.pdata.elements, txt)
 
     @DBG_PRINT ("Found CData : " * txt)
@@ -357,7 +357,7 @@ function find{T<:String}(pd::ETree, path::T)
             end
 
             if m.captures[3] != nothing
-                push!(xp, (:filter, (:number,int(m.captures[3]))))
+                push!(xp, (:filter, (:number, Base.parse(Int, m.captures[3]))))
                 idx = true
             end
         end

--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -60,7 +60,7 @@ cb_streaming_end_cdata = cfunction(streaming_end_cdata, Void, (Ptr{Void},))
 function streaming_cdata (p_cbs::Ptr{Void}, s::Ptr{Uint8}, len::Cint)
     h = unsafe_pointer_to_objref(p_cbs)::XPStreamHandler
 
-    txt = bytestring(s, int(len))
+    txt = bytestring(s, @compat(Int(len)))
 
     @DBG_PRINT ("Found CData : " * txt)
     h.cbs.character_data(h, txt)


### PR DESCRIPTION
Doing a Pkg.update() on the newest Julia nightly I receive a *LOT* of
```julia
WARNING: int(x) is deprecated, use Int(x) instead.
 in cdata at C:\cygwin64\home\Alex\.julia\v0.4\LibExpat\src\LibExpat.jl:166
```
slowing down the update process so much, that I actually canceled it after 10 minutes.

The provided ad-hoc patch solved this issue.
I did not check for other deprecated code, as I am not informed on these changes.

WARNING:
I do not know if this works with Julia 0.3.