### PR TITLE
Update LibExpat.jl

### DIFF
--- a/src/LibExpat.jl
+++ b/src/LibExpat.jl
@@ -17,7 +17,7 @@ export ParsedData # deprecated
 
 DEBUG = false
 
-macro DBG_PRINT (s)
+macro DBG_PRINT(s)
     quote
         if (DEBUG)
             println($s);


### PR DESCRIPTION
Fix deprecation warning from spaces between function name and "("