### PR TITLE
remove very long warning cycle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: julia
 os:
   - linux
 julia:
-  - release
+  - 0.3
+  - 0.4
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: julia
 os:
+  - osx
   - linux
 julia:
   - 0.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.3
-Compat 0.4.0
+Compat 0.7.1

--- a/src/LibExpat.jl
+++ b/src/LibExpat.jl
@@ -27,19 +27,19 @@ end
 
 type ETree
     # XML Tag
-    name::String
+    name::AbstractString
     # Dict of tag attributes as name-value pairs
-    attr::Dict{String,String}
+    attr::Dict{AbstractString,AbstractString}
     # List of child elements.
-    elements::Vector{@compat(Union{ETree,String})}
+    elements::Vector{@compat(Union{ETree,AbstractString})}
     parent::ETree
 
     ETree() = ETree("")
     function ETree(name)
         pd=new(
             name,
-            Dict{String, String}(),
-            @compat(Union{ETree,String})[])
+            Dict{AbstractString, AbstractString}(),
+            @compat(Union{ETree,AbstractString})[])
         pd.parent=pd
         pd
     end
@@ -69,8 +69,8 @@ end
 string_value(pd::ETree) = takebuf_string(string_value(pd,IOBuffer()))
 function string_value(pd::ETree, str::IOBuffer)
     for node in pd.elements
-        if isa(node, String)
-            write(str, node::String)
+        if isa(node, AbstractString)
+            write(str, node::AbstractString)
         elseif isa(node,ETree)
             string_value(node::ETree, str)
         end
@@ -199,7 +199,7 @@ end
 cb_default_expand = cfunction(default_expand, Void, (Ptr{Void},Ptr{UInt8}, Cint))
 
 function attrs_in_to_dict(attrs_in::Ptr{Ptr{UInt8}})
-    attrs = Dict{String,String}()
+    attrs = Dict{AbstractString,AbstractString}()
 
     if (attrs_in != C_NULL)
         i = 1
@@ -280,7 +280,7 @@ cb_end_namespace = cfunction(end_namespace, Void, (Ptr{Void},Ptr{UInt8}))
 
 
 
-function xp_parse(txt::String)
+function xp_parse(txt::AbstractString)
     xph = nothing
     xph = xp_make_parser()
 
@@ -302,7 +302,7 @@ function xp_parse(txt::String)
 end
 
 
-function find{T<:String}(pd::ETree, path::T)
+function find{T<:AbstractString}(pd::ETree, path::T)
     # What are we looking for?
     what = :node
     attr = ""

--- a/src/LibExpat.jl
+++ b/src/LibExpat.jl
@@ -160,7 +160,7 @@ end
 cb_end_cdata = cfunction(end_cdata, Void, (Ptr{Void},))
 
 
-function cdata(p_xph::Ptr{Void}, s::Ptr{Uint8}, len::Cint)
+function cdata(p_xph::Ptr{Void}, s::Ptr{UInt8}, len::Cint)
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
 
     txt = bytestring(s, @compat(Int(len)))
@@ -169,36 +169,36 @@ function cdata(p_xph::Ptr{Void}, s::Ptr{Uint8}, len::Cint)
     @DBG_PRINT("Found CData : " * txt)
     return;
 end
-cb_cdata = cfunction(cdata, Void, (Ptr{Void},Ptr{Uint8}, Cint))
+cb_cdata = cfunction(cdata, Void, (Ptr{Void},Ptr{UInt8}, Cint))
 
 
-function comment(p_xph::Ptr{Void}, data::Ptr{Uint8})
+function comment(p_xph::Ptr{Void}, data::Ptr{UInt8})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     txt = bytestring(data)
     @DBG_PRINT("Found comment : " * txt)
     return;
 end
-cb_comment = cfunction(comment, Void, (Ptr{Void},Ptr{Uint8}))
+cb_comment = cfunction(comment, Void, (Ptr{Void},Ptr{UInt8}))
 
 
-function default(p_xph::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
+function default(p_xph::Ptr{Void}, data::Ptr{UInt8}, len::Cint)
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     txt = bytestring(data)
     @DBG_PRINT("Default : " * txt)
     return;
 end
-cb_default = cfunction(default, Void, (Ptr{Void},Ptr{Uint8}, Cint))
+cb_default = cfunction(default, Void, (Ptr{Void},Ptr{UInt8}, Cint))
 
 
-function default_expand(p_xph::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
+function default_expand(p_xph::Ptr{Void}, data::Ptr{UInt8}, len::Cint)
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     txt = bytestring(data)
     @DBG_PRINT("Default Expand : " * txt)
     return;
 end
-cb_default_expand = cfunction(default_expand, Void, (Ptr{Void},Ptr{Uint8}, Cint))
+cb_default_expand = cfunction(default_expand, Void, (Ptr{Void},Ptr{UInt8}, Cint))
 
-function attrs_in_to_dict(attrs_in::Ptr{Ptr{Uint8}})
+function attrs_in_to_dict(attrs_in::Ptr{Ptr{UInt8}})
     attrs = Dict{String,String}()
 
     if (attrs_in != C_NULL)
@@ -225,7 +225,7 @@ function attrs_in_to_dict(attrs_in::Ptr{Ptr{Uint8}})
     return attrs
 end
 
-function start_element(p_xph::Ptr{Void}, name::Ptr{Uint8}, attrs_in::Ptr{Ptr{Uint8}})
+function start_element(p_xph::Ptr{Void}, name::Ptr{UInt8}, attrs_in::Ptr{Ptr{UInt8}})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     name = bytestring(name)
     @DBG_PRINT("Start Elem name : $name,  current element: $(xph.pdata.name) ")
@@ -241,10 +241,10 @@ function start_element(p_xph::Ptr{Void}, name::Ptr{Uint8}, attrs_in::Ptr{Ptr{Uin
 
     return
 end
-cb_start_element = cfunction(start_element, Void, (Ptr{Void},Ptr{Uint8}, Ptr{Ptr{Uint8}}))
+cb_start_element = cfunction(start_element, Void, (Ptr{Void},Ptr{UInt8}, Ptr{Ptr{UInt8}}))
 
 
-function end_element(p_xph::Ptr{Void}, name::Ptr{Uint8})
+function end_element(p_xph::Ptr{Void}, name::Ptr{UInt8})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     txt = bytestring(name)
     @DBG_PRINT("End element: $txt, current element: $(xph.pdata.name) ")
@@ -253,26 +253,26 @@ function end_element(p_xph::Ptr{Void}, name::Ptr{Uint8})
 
     return;
 end
-cb_end_element = cfunction(end_element, Void, (Ptr{Void},Ptr{Uint8}))
+cb_end_element = cfunction(end_element, Void, (Ptr{Void},Ptr{UInt8}))
 
 
-function start_namespace(p_xph::Ptr{Void}, prefix::Ptr{Uint8}, uri::Ptr{Uint8})
+function start_namespace(p_xph::Ptr{Void}, prefix::Ptr{UInt8}, uri::Ptr{UInt8})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     prefix = bytestring(prefix)
     uri = bytestring(uri)
     @DBG_PRINT("start namespace prefix : $prefix, uri: $uri")
     return;
 end
-cb_start_namespace = cfunction(start_namespace, Void, (Ptr{Void},Ptr{Uint8}, Ptr{Uint8}))
+cb_start_namespace = cfunction(start_namespace, Void, (Ptr{Void},Ptr{UInt8}, Ptr{UInt8}))
 
 
-function end_namespace(p_xph::Ptr{Void}, prefix::Ptr{Uint8})
+function end_namespace(p_xph::Ptr{Void}, prefix::Ptr{UInt8})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     prefix = bytestring(prefix)
     @DBG_PRINT("end namespace prefix : $prefix")
     return;
 end
-cb_end_namespace = cfunction(end_namespace, Void, (Ptr{Void},Ptr{Uint8}))
+cb_end_namespace = cfunction(end_namespace, Void, (Ptr{Void},Ptr{UInt8}))
 
 
 # Unsupported callbacks: External Entity, NotationDecl, Not Stand Alone, Processing, UnparsedEntityDecl, StartDocType

--- a/src/LibExpat.jl
+++ b/src/LibExpat.jl
@@ -31,7 +31,7 @@ type ETree
     # Dict of tag attributes as name-value pairs
     attr::Dict{String,String}
     # List of child elements.
-    elements::Vector{Union(ETree,String)}
+    elements::Vector{@compat(Union{ETree,String})}
     parent::ETree
 
     ETree() = ETree("")
@@ -39,7 +39,7 @@ type ETree
         pd=new(
             name,
             Dict{String, String}(),
-            Union(ETree,String)[])
+            @compat(Union{ETree,String})[])
         pd.parent=pd
         pd
     end
@@ -80,7 +80,7 @@ end
 
 
 type XPHandle
-  parser::Union(XML_Parser,Nothing)
+  parser::@compat(Union{XML_Parser,Nothing})
   pdata::ETree
   in_cdata::Bool
 
@@ -114,7 +114,7 @@ function xp_make_parser(sep='\0')
 end
 
 
-function xp_geterror(p::Union(XML_Parser,Nothing))
+function xp_geterror(p::@compat(Union{XML_Parser,Nothing}))
     ec = XML_GetErrorCode(p)
 
     if ec != 0

--- a/src/LibExpat.jl
+++ b/src/LibExpat.jl
@@ -1,7 +1,7 @@
 module LibExpat
 
 using Compat
-import Base: getindex, show
+import Base: getindex, show, find, parse
 
 @windows_only const libexpat = "libexpat-1"
 @unix_only const libexpat = "libexpat"
@@ -17,7 +17,7 @@ export ParsedData # deprecated
 
 DEBUG = false
 
-macro DBG_PRINT (s)
+macro DBG_PRINT(s)
     quote
         if (DEBUG)
             println($s);
@@ -114,20 +114,20 @@ function xp_make_parser(sep='\0')
 end
 
 
-function xp_geterror (p::Union(XML_Parser,Nothing))
+function xp_geterror(p::Union(XML_Parser,Nothing))
     ec = XML_GetErrorCode(p)
 
     if ec != 0
-        @DBG_PRINT (XML_GetErrorCode(p))
-        @DBG_PRINT (bytestring(XML_ErrorString(XML_GetErrorCode(p))))
+        @DBG_PRINT(XML_GetErrorCode(p))
+        @DBG_PRINT(bytestring(XML_ErrorString(XML_GetErrorCode(p))))
 
-        return  ( bytestring(XML_ErrorString(XML_GetErrorCode(p))),
+        return ( bytestring(XML_ErrorString(XML_GetErrorCode(p))),
                 XML_GetCurrentLineNumber(p),
                 XML_GetCurrentColumnNumber(p) + 1,
                 XML_GetCurrentByteIndex(p) + 1
             )
      else
-        return  ( "", 0, 0, 0)
+        return ( "", 0, 0, 0)
      end
 
 end
@@ -137,63 +137,63 @@ function xp_geterror(xph::XPHandle)
 end
 
 
-function xp_close (xph::XPHandle)
+function xp_close(xph::XPHandle)
   if (xph.parser != nothing)    XML_ParserFree(xph.parser) end
   xph.parser = nothing
 end
 
 
-function start_cdata (p_xph::Ptr{Void})
+function start_cdata(p_xph::Ptr{Void})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
-    @DBG_PRINT ("Found StartCdata")
+    @DBG_PRINT("Found StartCdata")
     xph.in_cdata = true
     return
 end
 cb_start_cdata = cfunction(start_cdata, Void, (Ptr{Void},))
 
-function end_cdata (p_xph::Ptr{Void})
+function end_cdata(p_xph::Ptr{Void})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
-    @DBG_PRINT ("Found EndCdata")
+    @DBG_PRINT("Found EndCdata")
     xph.in_cdata = false
     return;
 end
 cb_end_cdata = cfunction(end_cdata, Void, (Ptr{Void},))
 
 
-function cdata (p_xph::Ptr{Void}, s::Ptr{Uint8}, len::Cint)
+function cdata(p_xph::Ptr{Void}, s::Ptr{Uint8}, len::Cint)
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
 
     txt = bytestring(s, @compat(Int(len)))
     push!(xph.pdata.elements, txt)
 
-    @DBG_PRINT ("Found CData : " * txt)
+    @DBG_PRINT("Found CData : " * txt)
     return;
 end
 cb_cdata = cfunction(cdata, Void, (Ptr{Void},Ptr{Uint8}, Cint))
 
 
-function comment (p_xph::Ptr{Void}, data::Ptr{Uint8})
+function comment(p_xph::Ptr{Void}, data::Ptr{Uint8})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     txt = bytestring(data)
-    @DBG_PRINT ("Found comment : " * txt)
+    @DBG_PRINT("Found comment : " * txt)
     return;
 end
 cb_comment = cfunction(comment, Void, (Ptr{Void},Ptr{Uint8}))
 
 
-function default (p_xph::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
+function default(p_xph::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     txt = bytestring(data)
-    @DBG_PRINT ("Default : " * txt)
+    @DBG_PRINT("Default : " * txt)
     return;
 end
 cb_default = cfunction(default, Void, (Ptr{Void},Ptr{Uint8}, Cint))
 
 
-function default_expand (p_xph::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
+function default_expand(p_xph::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     txt = bytestring(data)
-    @DBG_PRINT ("Default Expand : " * txt)
+    @DBG_PRINT("Default Expand : " * txt)
     return;
 end
 cb_default_expand = cfunction(default_expand, Void, (Ptr{Void},Ptr{Uint8}, Cint))
@@ -215,7 +215,7 @@ function attrs_in_to_dict(attrs_in::Ptr{Ptr{Uint8}})
 
             attrs[k] = v
 
-            @DBG_PRINT ("$k, $v in $name")
+            @DBG_PRINT("$k, $v in $name")
 
             i=i+1
             attr = unsafe_load(attrs_in, i)
@@ -225,16 +225,16 @@ function attrs_in_to_dict(attrs_in::Ptr{Ptr{Uint8}})
     return attrs
 end
 
-function start_element (p_xph::Ptr{Void}, name::Ptr{Uint8}, attrs_in::Ptr{Ptr{Uint8}})
+function start_element(p_xph::Ptr{Void}, name::Ptr{Uint8}, attrs_in::Ptr{Ptr{Uint8}})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     name = bytestring(name)
-    @DBG_PRINT ("Start Elem name : $name,  current element: $(xph.pdata.name) ")
+    @DBG_PRINT("Start Elem name : $name,  current element: $(xph.pdata.name) ")
 
     new_elem = ETree(name)
     new_elem.parent = xph.pdata
 
     push!(xph.pdata.elements, new_elem)
-    @DBG_PRINT ("Found  $name")
+    @DBG_PRINT("Found  $name")
 
     merge!(new_elem.attr, attrs_in_to_dict(attrs_in))
     xph.pdata = new_elem
@@ -244,10 +244,10 @@ end
 cb_start_element = cfunction(start_element, Void, (Ptr{Void},Ptr{Uint8}, Ptr{Ptr{Uint8}}))
 
 
-function end_element (p_xph::Ptr{Void}, name::Ptr{Uint8})
+function end_element(p_xph::Ptr{Void}, name::Ptr{Uint8})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     txt = bytestring(name)
-    @DBG_PRINT ("End element: $txt, current element: $(xph.pdata.name) ")
+    @DBG_PRINT("End element: $txt, current element: $(xph.pdata.name) ")
 
     xph.pdata = xph.pdata.parent
 
@@ -256,20 +256,20 @@ end
 cb_end_element = cfunction(end_element, Void, (Ptr{Void},Ptr{Uint8}))
 
 
-function start_namespace (p_xph::Ptr{Void}, prefix::Ptr{Uint8}, uri::Ptr{Uint8})
+function start_namespace(p_xph::Ptr{Void}, prefix::Ptr{Uint8}, uri::Ptr{Uint8})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     prefix = bytestring(prefix)
     uri = bytestring(uri)
-    @DBG_PRINT ("start namespace prefix : $prefix, uri: $uri")
+    @DBG_PRINT("start namespace prefix : $prefix, uri: $uri")
     return;
 end
 cb_start_namespace = cfunction(start_namespace, Void, (Ptr{Void},Ptr{Uint8}, Ptr{Uint8}))
 
 
-function end_namespace (p_xph::Ptr{Void}, prefix::Ptr{Uint8})
+function end_namespace(p_xph::Ptr{Void}, prefix::Ptr{Uint8})
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
     prefix = bytestring(prefix)
-    @DBG_PRINT ("end namespace prefix : $prefix")
+    @DBG_PRINT("end namespace prefix : $prefix")
     return;
 end
 cb_end_namespace = cfunction(end_namespace, Void, (Ptr{Void},Ptr{Uint8}))
@@ -293,7 +293,7 @@ function xp_parse(txt::String)
     catch e
         stre = string(e)
         (err, line, column, pos) = xp_geterror(xph)
-        @DBG_PRINT ("$e, $err, $line, $column, $pos")
+        @DBG_PRINT("$e, $err, $line, $column, $pos")
         rethrow("$e, $err, $line, $column, $pos")
 
     finally

--- a/src/LibExpat.jl
+++ b/src/LibExpat.jl
@@ -1,7 +1,7 @@
 module LibExpat
 
 using Compat
-import Base: getindex, show, find, parse
+import Base: getindex, show, parse
 
 @windows_only const libexpat = "libexpat-1"
 @unix_only const libexpat = "libexpat"
@@ -12,7 +12,7 @@ include("lX_expat_h.jl")
 
 @c Ptr{XML_LChar} XML_ErrorString (Cint,) libexpat
 
-export ETree, xp_parse, find, xpath, @xpath_str
+export ETree, xp_parse, xpath, @xpath_str
 export ParsedData # deprecated
 
 DEBUG = false

--- a/src/LibExpat.jl
+++ b/src/LibExpat.jl
@@ -80,7 +80,7 @@ end
 
 
 type XPHandle
-  parser::@compat(Union{XML_Parser,Nothing})
+  parser::@compat(Union{XML_Parser,Void})
   pdata::ETree
   in_cdata::Bool
 
@@ -114,7 +114,7 @@ function xp_make_parser(sep='\0')
 end
 
 
-function xp_geterror(p::@compat(Union{XML_Parser,Nothing}))
+function xp_geterror(p::@compat(Union{XML_Parser,Void}))
     ec = XML_GetErrorCode(p)
 
     if ec != 0

--- a/src/lX_common_h.jl
+++ b/src/lX_common_h.jl
@@ -11,12 +11,12 @@ macro ctypedef(fake_t,real_t)
   end
 end
 
-@ctypedef XML_Char Uint8
-@ctypedef XML_LChar Uint8
+@ctypedef XML_Char UInt8
+@ctypedef XML_LChar UInt8
 @ctypedef XML_Index Int32
-@ctypedef XML_Size Uint32
+@ctypedef XML_Size UInt32
 @ctypedef XML_Parser Ptr{Void}
-@ctypedef XML_Bool Uint8
+@ctypedef XML_Bool UInt8
 # enum XML_Status
 const XML_STATUS_ERROR = 0
 const XML_STATUS_OK = 1

--- a/src/lX_expat_h.jl
+++ b/src/lX_expat_h.jl
@@ -1,43 +1,43 @@
 # Julia wrapper for header: /usr/include/expat.h
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-@c None XML_SetElementDeclHandler (XML_Parser, XML_ElementDeclHandler) libexpat
-@c None XML_SetAttlistDeclHandler (XML_Parser, XML_AttlistDeclHandler) libexpat
-@c None XML_SetXmlDeclHandler (XML_Parser, XML_XmlDeclHandler) libexpat
+@c @compat(Union{}) XML_SetElementDeclHandler (XML_Parser, XML_ElementDeclHandler) libexpat
+@c @compat(Union{}) XML_SetAttlistDeclHandler (XML_Parser, XML_AttlistDeclHandler) libexpat
+@c @compat(Union{}) XML_SetXmlDeclHandler (XML_Parser, XML_XmlDeclHandler) libexpat
 @c XML_Parser XML_ParserCreate (Ptr{XML_Char},) libexpat
 @c XML_Parser XML_ParserCreateNS (Ptr{XML_Char}, XML_Char) libexpat
 @c XML_Parser XML_ParserCreate_MM (Ptr{XML_Char}, Ptr{XML_Memory_Handling_Suite}, Ptr{XML_Char}) libexpat
 @c XML_Bool XML_ParserReset (XML_Parser, Ptr{XML_Char}) libexpat
-@c None XML_SetEntityDeclHandler (XML_Parser, XML_EntityDeclHandler) libexpat
-@c None XML_SetElementHandler (XML_Parser, XML_StartElementHandler, XML_EndElementHandler) libexpat
-@c None XML_SetStartElementHandler (XML_Parser, XML_StartElementHandler) libexpat
-@c None XML_SetEndElementHandler (XML_Parser, XML_EndElementHandler) libexpat
-@c None XML_SetCharacterDataHandler (XML_Parser, XML_CharacterDataHandler) libexpat
-@c None XML_SetProcessingInstructionHandler (XML_Parser, XML_ProcessingInstructionHandler) libexpat
-@c None XML_SetCommentHandler (XML_Parser, XML_CommentHandler) libexpat
-@c None XML_SetCdataSectionHandler (XML_Parser, XML_StartCdataSectionHandler, XML_EndCdataSectionHandler) libexpat
-@c None XML_SetStartCdataSectionHandler (XML_Parser, XML_StartCdataSectionHandler) libexpat
-@c None XML_SetEndCdataSectionHandler (XML_Parser, XML_EndCdataSectionHandler) libexpat
-@c None XML_SetDefaultHandler (XML_Parser, XML_DefaultHandler) libexpat
-@c None XML_SetDefaultHandlerExpand (XML_Parser, XML_DefaultHandler) libexpat
-@c None XML_SetDoctypeDeclHandler (XML_Parser, XML_StartDoctypeDeclHandler, XML_EndDoctypeDeclHandler) libexpat
-@c None XML_SetStartDoctypeDeclHandler (XML_Parser, XML_StartDoctypeDeclHandler) libexpat
-@c None XML_SetEndDoctypeDeclHandler (XML_Parser, XML_EndDoctypeDeclHandler) libexpat
-@c None XML_SetUnparsedEntityDeclHandler (XML_Parser, XML_UnparsedEntityDeclHandler) libexpat
-@c None XML_SetNotationDeclHandler (XML_Parser, XML_NotationDeclHandler) libexpat
-@c None XML_SetNamespaceDeclHandler (XML_Parser, XML_StartNamespaceDeclHandler, XML_EndNamespaceDeclHandler) libexpat
-@c None XML_SetStartNamespaceDeclHandler (XML_Parser, XML_StartNamespaceDeclHandler) libexpat
-@c None XML_SetEndNamespaceDeclHandler (XML_Parser, XML_EndNamespaceDeclHandler) libexpat
-@c None XML_SetNotStandaloneHandler (XML_Parser, XML_NotStandaloneHandler) libexpat
-@c None XML_SetExternalEntityRefHandler (XML_Parser, XML_ExternalEntityRefHandler) libexpat
-@c None XML_SetExternalEntityRefHandlerArg (XML_Parser, Ptr{Void}) libexpat
-@c None XML_SetSkippedEntityHandler (XML_Parser, XML_SkippedEntityHandler) libexpat
-@c None XML_SetUnknownEncodingHandler (XML_Parser, XML_UnknownEncodingHandler, Ptr{Void}) libexpat
-@c None XML_DefaultCurrent (XML_Parser,) libexpat
-@c None XML_SetReturnNSTriplet (XML_Parser, Int32) libexpat
-@c None XML_SetUserData (XML_Parser, Ptr{Void}) libexpat
+@c @compat(Union{}) XML_SetEntityDeclHandler (XML_Parser, XML_EntityDeclHandler) libexpat
+@c @compat(Union{}) XML_SetElementHandler (XML_Parser, XML_StartElementHandler, XML_EndElementHandler) libexpat
+@c @compat(Union{}) XML_SetStartElementHandler (XML_Parser, XML_StartElementHandler) libexpat
+@c @compat(Union{}) XML_SetEndElementHandler (XML_Parser, XML_EndElementHandler) libexpat
+@c @compat(Union{}) XML_SetCharacterDataHandler (XML_Parser, XML_CharacterDataHandler) libexpat
+@c @compat(Union{}) XML_SetProcessingInstructionHandler (XML_Parser, XML_ProcessingInstructionHandler) libexpat
+@c @compat(Union{}) XML_SetCommentHandler (XML_Parser, XML_CommentHandler) libexpat
+@c @compat(Union{}) XML_SetCdataSectionHandler (XML_Parser, XML_StartCdataSectionHandler, XML_EndCdataSectionHandler) libexpat
+@c @compat(Union{}) XML_SetStartCdataSectionHandler (XML_Parser, XML_StartCdataSectionHandler) libexpat
+@c @compat(Union{}) XML_SetEndCdataSectionHandler (XML_Parser, XML_EndCdataSectionHandler) libexpat
+@c @compat(Union{}) XML_SetDefaultHandler (XML_Parser, XML_DefaultHandler) libexpat
+@c @compat(Union{}) XML_SetDefaultHandlerExpand (XML_Parser, XML_DefaultHandler) libexpat
+@c @compat(Union{}) XML_SetDoctypeDeclHandler (XML_Parser, XML_StartDoctypeDeclHandler, XML_EndDoctypeDeclHandler) libexpat
+@c @compat(Union{}) XML_SetStartDoctypeDeclHandler (XML_Parser, XML_StartDoctypeDeclHandler) libexpat
+@c @compat(Union{}) XML_SetEndDoctypeDeclHandler (XML_Parser, XML_EndDoctypeDeclHandler) libexpat
+@c @compat(Union{}) XML_SetUnparsedEntityDeclHandler (XML_Parser, XML_UnparsedEntityDeclHandler) libexpat
+@c @compat(Union{}) XML_SetNotationDeclHandler (XML_Parser, XML_NotationDeclHandler) libexpat
+@c @compat(Union{}) XML_SetNamespaceDeclHandler (XML_Parser, XML_StartNamespaceDeclHandler, XML_EndNamespaceDeclHandler) libexpat
+@c @compat(Union{}) XML_SetStartNamespaceDeclHandler (XML_Parser, XML_StartNamespaceDeclHandler) libexpat
+@c @compat(Union{}) XML_SetEndNamespaceDeclHandler (XML_Parser, XML_EndNamespaceDeclHandler) libexpat
+@c @compat(Union{}) XML_SetNotStandaloneHandler (XML_Parser, XML_NotStandaloneHandler) libexpat
+@c @compat(Union{}) XML_SetExternalEntityRefHandler (XML_Parser, XML_ExternalEntityRefHandler) libexpat
+@c @compat(Union{}) XML_SetExternalEntityRefHandlerArg (XML_Parser, Ptr{Void}) libexpat
+@c @compat(Union{}) XML_SetSkippedEntityHandler (XML_Parser, XML_SkippedEntityHandler) libexpat
+@c @compat(Union{}) XML_SetUnknownEncodingHandler (XML_Parser, XML_UnknownEncodingHandler, Ptr{Void}) libexpat
+@c @compat(Union{}) XML_DefaultCurrent (XML_Parser,) libexpat
+@c @compat(Union{}) XML_SetReturnNSTriplet (XML_Parser, Int32) libexpat
+@c @compat(Union{}) XML_SetUserData (XML_Parser, Ptr{Void}) libexpat
 @c Int32 XML_SetEncoding (XML_Parser, Ptr{XML_Char}) libexpat
-@c None XML_UseParserAsHandlerArg (XML_Parser,) libexpat
+@c @compat(Union{}) XML_UseParserAsHandlerArg (XML_Parser,) libexpat
 @c Int32 XML_UseForeignDTD (XML_Parser, XML_Bool) libexpat
 @c Int32 XML_SetBase (XML_Parser, Ptr{XML_Char}) libexpat
 @c Ptr{XML_Char} XML_GetBase (XML_Parser,) libexpat
@@ -48,7 +48,7 @@
 @c Int32 XML_ParseBuffer (XML_Parser, Int32, Int32) libexpat
 @c Int32 XML_StopParser (XML_Parser, XML_Bool) libexpat
 @c Int32 XML_ResumeParser (XML_Parser,) libexpat
-@c None XML_GetParsingStatus (XML_Parser, Ptr{XML_ParsingStatus}) libexpat
+@c @compat(Union{}) XML_GetParsingStatus (XML_Parser, Ptr{XML_ParsingStatus}) libexpat
 @c XML_Parser XML_ExternalEntityParserCreate (XML_Parser, Ptr{XML_Char}, Ptr{XML_Char}) libexpat
 @c Int32 XML_SetParamEntityParsing (XML_Parser, Void) libexpat
 @c Int32 XML_SetHashSalt (XML_Parser, UInt32) libexpat
@@ -58,11 +58,11 @@
 @c XML_Index XML_GetCurrentByteIndex (XML_Parser,) libexpat
 @c Int32 XML_GetCurrentByteCount (XML_Parser,) libexpat
 @c Ptr{UInt8} XML_GetInputContext (XML_Parser, Ptr{Int32}, Ptr{Int32}) libexpat
-@c None XML_FreeContentModel (XML_Parser, Ptr{XML_Content}) libexpat
+@c @compat(Union{}) XML_FreeContentModel (XML_Parser, Ptr{XML_Content}) libexpat
 @c Ptr{Void} XML_MemMalloc (XML_Parser, size_t) libexpat
 @c Ptr{Void} XML_MemRealloc (XML_Parser, Ptr{Void}, size_t) libexpat
-@c None XML_MemFree (XML_Parser, Ptr{Void}) libexpat
-@c None XML_ParserFree (XML_Parser,) libexpat
+@c @compat(Union{}) XML_MemFree (XML_Parser, Ptr{Void}) libexpat
+@c @compat(Union{}) XML_ParserFree (XML_Parser,) libexpat
 @c Ptr{XML_LChar} XML_ErrorString (Void,) libexpat
 @c Ptr{XML_LChar} XML_ExpatVersion () libexpat
 @c XML_Expat_Version XML_ExpatVersionInfo () libexpat

--- a/src/lX_expat_h.jl
+++ b/src/lX_expat_h.jl
@@ -43,7 +43,7 @@
 @c Ptr{XML_Char} XML_GetBase (XML_Parser,) libexpat
 @c Int32 XML_GetSpecifiedAttributeCount (XML_Parser,) libexpat
 @c Int32 XML_GetIdAttributeIndex (XML_Parser,) libexpat
-@c Int32 XML_Parse (XML_Parser, Ptr{Uint8}, Int32, Int32) libexpat
+@c Int32 XML_Parse (XML_Parser, Ptr{UInt8}, Int32, Int32) libexpat
 @c Ptr{Void} XML_GetBuffer (XML_Parser, Int32) libexpat
 @c Int32 XML_ParseBuffer (XML_Parser, Int32, Int32) libexpat
 @c Int32 XML_StopParser (XML_Parser, XML_Bool) libexpat
@@ -51,13 +51,13 @@
 @c None XML_GetParsingStatus (XML_Parser, Ptr{XML_ParsingStatus}) libexpat
 @c XML_Parser XML_ExternalEntityParserCreate (XML_Parser, Ptr{XML_Char}, Ptr{XML_Char}) libexpat
 @c Int32 XML_SetParamEntityParsing (XML_Parser, Void) libexpat
-@c Int32 XML_SetHashSalt (XML_Parser, Uint32) libexpat
+@c Int32 XML_SetHashSalt (XML_Parser, UInt32) libexpat
 @c Int32 XML_GetErrorCode (XML_Parser,) libexpat
 @c XML_Size XML_GetCurrentLineNumber (XML_Parser,) libexpat
 @c XML_Size XML_GetCurrentColumnNumber (XML_Parser,) libexpat
 @c XML_Index XML_GetCurrentByteIndex (XML_Parser,) libexpat
 @c Int32 XML_GetCurrentByteCount (XML_Parser,) libexpat
-@c Ptr{Uint8} XML_GetInputContext (XML_Parser, Ptr{Int32}, Ptr{Int32}) libexpat
+@c Ptr{UInt8} XML_GetInputContext (XML_Parser, Ptr{Int32}, Ptr{Int32}) libexpat
 @c None XML_FreeContentModel (XML_Parser, Ptr{XML_Content}) libexpat
 @c Ptr{Void} XML_MemMalloc (XML_Parser, size_t) libexpat
 @c Ptr{Void} XML_MemRealloc (XML_Parser, Ptr{Void}, size_t) libexpat

--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -14,14 +14,14 @@ type XPCallbacks
     function XPCallbacks()
         start_cdata = (handler::XPStreamHandler) -> nothing
         end_cdata = (handler::XPStreamHandler) -> nothing
-        comment = (handler::XPStreamHandler, txt::String) -> nothing
-        character_data = (handler::XPStreamHandler, txt::String) -> nothing
-        default = (handler::XPStreamHandler, txt::String) -> nothing
-        default_expand = (handler::XPStreamHandler, txt::String) -> nothing
-        start_element = (handler::XPStreamHandler, name::String, attrs_in::Dict{String,String}) -> nothing
-        end_element = (handler::XPStreamHandler, name::String) -> nothing
-        start_namespace = (handler::XPStreamHandler, prefix::String, uri::String) -> nothing
-        end_namespace = (handler::XPStreamHandler, prefix::String) -> nothing
+        comment = (handler::XPStreamHandler, txt::AbstractString) -> nothing
+        character_data = (handler::XPStreamHandler, txt::AbstractString) -> nothing
+        default = (handler::XPStreamHandler, txt::AbstractString) -> nothing
+        default_expand = (handler::XPStreamHandler, txt::AbstractString) -> nothing
+        start_element = (handler::XPStreamHandler, name::AbstractString, attrs_in::Dict{AbstractString,AbstractString}) -> nothing
+        end_element = (handler::XPStreamHandler, name::AbstractString) -> nothing
+        start_namespace = (handler::XPStreamHandler, prefix::AbstractString, uri::AbstractString) -> nothing
+        end_namespace = (handler::XPStreamHandler, prefix::AbstractString) -> nothing
 
         new(start_cdata, end_cdata, comment, character_data, default,
             default_expand, start_element, end_element, start_namespace,
@@ -72,8 +72,8 @@ cb_streaming_cdata = cfunction(streaming_cdata, Void, (Ptr{Void},Ptr{UInt8}, Cin
 
 function streaming_start_element(p_cbs::Ptr{Void}, name::Ptr{UInt8}, attrs_in::Ptr{Ptr{UInt8}})
     h = unsafe_pointer_to_objref(p_cbs)::XPStreamHandler
-    txt::String = bytestring(name)
-    attrs::Dict{String,String} = attrs_in_to_dict(attrs_in)
+    txt::AbstractString = bytestring(name)
+    attrs::Dict{AbstractString,AbstractString} = attrs_in_to_dict(attrs_in)
 
     h.cbs.start_element(h, txt, attrs)
 
@@ -84,7 +84,7 @@ cb_streaming_start_element = cfunction(streaming_start_element, Void, (Ptr{Void}
 
 function streaming_end_element(p_h::Ptr{Void}, name::Ptr{UInt8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
-    txt::String = bytestring(name)
+    txt::AbstractString = bytestring(name)
     @DBG_PRINT("End element: $txt, current element: $(xph.pdata.name) ")
 
     h.cbs.end_element(h, txt)
@@ -204,7 +204,7 @@ function free(h::XPStreamHandler)
     XML_ParserFree(h.parser)
 end
 
-function parsefile(filename::String,callbacks::XPCallbacks; bufferlines=1024, data=nothing)
+function parsefile(filename::AbstractString,callbacks::XPCallbacks; bufferlines=1024, data=nothing)
     h = make_parser(callbacks, data)
     # TODO: Support suspending for files too
     suspended = false
@@ -250,7 +250,7 @@ function parsefile(filename::String,callbacks::XPCallbacks; bufferlines=1024, da
     end
 end
 
-function parse(txt::String,callbacks::XPCallbacks; data=nothing)
+function parse(txt::AbstractString,callbacks::XPCallbacks; data=nothing)
     h = make_parser(callbacks, data)
     suspended = false
 

--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -57,7 +57,7 @@ end
 cb_streaming_end_cdata = cfunction(streaming_end_cdata, Void, (Ptr{Void},))
 
 
-function streaming_cdata(p_cbs::Ptr{Void}, s::Ptr{Uint8}, len::Cint)
+function streaming_cdata(p_cbs::Ptr{Void}, s::Ptr{UInt8}, len::Cint)
     h = unsafe_pointer_to_objref(p_cbs)::XPStreamHandler
 
     txt = bytestring(s, @compat(Int(len)))
@@ -67,10 +67,10 @@ function streaming_cdata(p_cbs::Ptr{Void}, s::Ptr{Uint8}, len::Cint)
 
     return;
 end
-cb_streaming_cdata = cfunction(streaming_cdata, Void, (Ptr{Void},Ptr{Uint8}, Cint))
+cb_streaming_cdata = cfunction(streaming_cdata, Void, (Ptr{Void},Ptr{UInt8}, Cint))
 
 
-function streaming_start_element(p_cbs::Ptr{Void}, name::Ptr{Uint8}, attrs_in::Ptr{Ptr{Uint8}})
+function streaming_start_element(p_cbs::Ptr{Void}, name::Ptr{UInt8}, attrs_in::Ptr{Ptr{UInt8}})
     h = unsafe_pointer_to_objref(p_cbs)::XPStreamHandler
     txt::String = bytestring(name)
     attrs::Dict{String,String} = attrs_in_to_dict(attrs_in)
@@ -79,10 +79,10 @@ function streaming_start_element(p_cbs::Ptr{Void}, name::Ptr{Uint8}, attrs_in::P
 
     return
 end
-cb_streaming_start_element = cfunction(streaming_start_element, Void, (Ptr{Void},Ptr{Uint8}, Ptr{Ptr{Uint8}}))
+cb_streaming_start_element = cfunction(streaming_start_element, Void, (Ptr{Void},Ptr{UInt8}, Ptr{Ptr{UInt8}}))
 
 
-function streaming_end_element(p_h::Ptr{Void}, name::Ptr{Uint8})
+function streaming_end_element(p_h::Ptr{Void}, name::Ptr{UInt8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt::String = bytestring(name)
     @DBG_PRINT("End element: $txt, current element: $(xph.pdata.name) ")
@@ -91,9 +91,9 @@ function streaming_end_element(p_h::Ptr{Void}, name::Ptr{Uint8})
 
     return
 end
-cb_streaming_end_element = cfunction(streaming_end_element, Void, (Ptr{Void},Ptr{Uint8}))
+cb_streaming_end_element = cfunction(streaming_end_element, Void, (Ptr{Void},Ptr{UInt8}))
 
-function streaming_comment(p_h::Ptr{Void}, data::Ptr{Uint8})
+function streaming_comment(p_h::Ptr{Void}, data::Ptr{UInt8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt = bytestring(data)
     @DBG_PRINT("Found comment : " * txt)
@@ -102,10 +102,10 @@ function streaming_comment(p_h::Ptr{Void}, data::Ptr{Uint8})
 
     return
 end
-cb_streaming_comment = cfunction(streaming_comment, Void, (Ptr{Void},Ptr{Uint8}))
+cb_streaming_comment = cfunction(streaming_comment, Void, (Ptr{Void},Ptr{UInt8}))
 
 
-function streaming_default(p_h::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
+function streaming_default(p_h::Ptr{Void}, data::Ptr{UInt8}, len::Cint)
     xph = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt = bytestring(data)
     @DBG_PRINT("Default : " * txt)
@@ -114,10 +114,10 @@ function streaming_default(p_h::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
 
     return;
 end
-cb_streaming_default = cfunction(streaming_default, Void, (Ptr{Void},Ptr{Uint8}, Cint))
+cb_streaming_default = cfunction(streaming_default, Void, (Ptr{Void},Ptr{UInt8}, Cint))
 
 
-function streaming_default_expand(p_h::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
+function streaming_default_expand(p_h::Ptr{Void}, data::Ptr{UInt8}, len::Cint)
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt = bytestring(data)
     @DBG_PRINT("Default Expand : " * txt)
@@ -126,10 +126,10 @@ function streaming_default_expand(p_h::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
 
     return;
 end
-cb_streaming_default_expand = cfunction(streaming_default_expand, Void, (Ptr{Void},Ptr{Uint8}, Cint))
+cb_streaming_default_expand = cfunction(streaming_default_expand, Void, (Ptr{Void},Ptr{UInt8}, Cint))
 
 
-function streaming_start_namespace(p_h::Ptr{Void}, prefix::Ptr{Uint8}, uri::Ptr{Uint8})
+function streaming_start_namespace(p_h::Ptr{Void}, prefix::Ptr{UInt8}, uri::Ptr{UInt8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     prefix = bytestring(prefix)
     uri = bytestring(uri)
@@ -139,10 +139,10 @@ function streaming_start_namespace(p_h::Ptr{Void}, prefix::Ptr{Uint8}, uri::Ptr{
 
     return;
 end
-cb_streaming_start_namespace = cfunction(streaming_start_namespace, Void, (Ptr{Void},Ptr{Uint8}, Ptr{Uint8}))
+cb_streaming_start_namespace = cfunction(streaming_start_namespace, Void, (Ptr{Void},Ptr{UInt8}, Ptr{UInt8}))
 
 
-function streaming_end_namespace(p_h::Ptr{Void}, prefix::Ptr{Uint8})
+function streaming_end_namespace(p_h::Ptr{Void}, prefix::Ptr{UInt8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     prefix = bytestring(prefix)
     @DBG_PRINT("end namespace prefix : $prefix")
@@ -151,7 +151,7 @@ function streaming_end_namespace(p_h::Ptr{Void}, prefix::Ptr{Uint8})
 
     return;
 end
-cb_streaming_end_namespace = cfunction(streaming_end_namespace, Void, (Ptr{Void},Ptr{Uint8}))
+cb_streaming_end_namespace = cfunction(streaming_end_namespace, Void, (Ptr{Void},Ptr{UInt8}))
 
 
 # Unsupported callbacks: External Entity, NotationDecl, Not Stand Alone, Processing, UnparsedEntityDecl, StartDocType

--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -37,8 +37,8 @@ type XPStreamHandler{D}
 end
 
 
-function streaming_start_cdata (p_cbs::Ptr{Void})
-    @DBG_PRINT ("Found StartCdata")
+function streaming_start_cdata(p_cbs::Ptr{Void})
+    @DBG_PRINT("Found StartCdata")
     h = unsafe_pointer_to_objref(p_cbs)::XPStreamHandler
 
     h.cbs.start_cdata(h)
@@ -47,8 +47,8 @@ end
 cb_streaming_start_cdata = cfunction(streaming_start_cdata, Void, (Ptr{Void},))
 
 
-function streaming_end_cdata (p_cbs::Ptr{Void})
-    @DBG_PRINT ("Found EndCdata")
+function streaming_end_cdata(p_cbs::Ptr{Void})
+    @DBG_PRINT("Found EndCdata")
     h = unsafe_pointer_to_objref(p_cbs)::XPStreamHandler
 
     h.cbs.end_cdata(h)
@@ -57,12 +57,12 @@ end
 cb_streaming_end_cdata = cfunction(streaming_end_cdata, Void, (Ptr{Void},))
 
 
-function streaming_cdata (p_cbs::Ptr{Void}, s::Ptr{Uint8}, len::Cint)
+function streaming_cdata(p_cbs::Ptr{Void}, s::Ptr{Uint8}, len::Cint)
     h = unsafe_pointer_to_objref(p_cbs)::XPStreamHandler
 
     txt = bytestring(s, @compat(Int(len)))
 
-    @DBG_PRINT ("Found CData : " * txt)
+    @DBG_PRINT("Found CData : " * txt)
     h.cbs.character_data(h, txt)
 
     return;
@@ -85,7 +85,7 @@ cb_streaming_start_element = cfunction(streaming_start_element, Void, (Ptr{Void}
 function streaming_end_element(p_h::Ptr{Void}, name::Ptr{Uint8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt::String = bytestring(name)
-    @DBG_PRINT ("End element: $txt, current element: $(xph.pdata.name) ")
+    @DBG_PRINT("End element: $txt, current element: $(xph.pdata.name) ")
 
     h.cbs.end_element(h, txt)
 
@@ -93,10 +93,10 @@ function streaming_end_element(p_h::Ptr{Void}, name::Ptr{Uint8})
 end
 cb_streaming_end_element = cfunction(streaming_end_element, Void, (Ptr{Void},Ptr{Uint8}))
 
-function streaming_comment (p_h::Ptr{Void}, data::Ptr{Uint8})
+function streaming_comment(p_h::Ptr{Void}, data::Ptr{Uint8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt = bytestring(data)
-    @DBG_PRINT ("Found comment : " * txt)
+    @DBG_PRINT("Found comment : " * txt)
 
     h.cbs.comment(h, txt)
 
@@ -105,10 +105,10 @@ end
 cb_streaming_comment = cfunction(streaming_comment, Void, (Ptr{Void},Ptr{Uint8}))
 
 
-function streaming_default (p_h::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
+function streaming_default(p_h::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
     xph = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt = bytestring(data)
-    @DBG_PRINT ("Default : " * txt)
+    @DBG_PRINT("Default : " * txt)
 
     h.cbs.default(h, txt)
 
@@ -117,10 +117,10 @@ end
 cb_streaming_default = cfunction(streaming_default, Void, (Ptr{Void},Ptr{Uint8}, Cint))
 
 
-function streaming_default_expand (p_h::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
+function streaming_default_expand(p_h::Ptr{Void}, data::Ptr{Uint8}, len::Cint)
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt = bytestring(data)
-    @DBG_PRINT ("Default Expand : " * txt)
+    @DBG_PRINT("Default Expand : " * txt)
 
     h.cbs.default_expand(h, txt)
 
@@ -129,11 +129,11 @@ end
 cb_streaming_default_expand = cfunction(streaming_default_expand, Void, (Ptr{Void},Ptr{Uint8}, Cint))
 
 
-function streaming_start_namespace (p_h::Ptr{Void}, prefix::Ptr{Uint8}, uri::Ptr{Uint8})
+function streaming_start_namespace(p_h::Ptr{Void}, prefix::Ptr{Uint8}, uri::Ptr{Uint8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     prefix = bytestring(prefix)
     uri = bytestring(uri)
-    @DBG_PRINT ("start namespace prefix : $prefix, uri: $uri")
+    @DBG_PRINT("start namespace prefix : $prefix, uri: $uri")
 
     h.cbs.start_namespace(h, prefix, uri)
 
@@ -142,10 +142,10 @@ end
 cb_streaming_start_namespace = cfunction(streaming_start_namespace, Void, (Ptr{Void},Ptr{Uint8}, Ptr{Uint8}))
 
 
-function streaming_end_namespace (p_h::Ptr{Void}, prefix::Ptr{Uint8})
+function streaming_end_namespace(p_h::Ptr{Void}, prefix::Ptr{Uint8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     prefix = bytestring(prefix)
-    @DBG_PRINT ("end namespace prefix : $prefix")
+    @DBG_PRINT("end namespace prefix : $prefix")
 
     h.cbs.end_namespace(h, prefix)
 
@@ -240,7 +240,7 @@ function parsefile(filename::String,callbacks::XPCallbacks; bufferlines=1024, da
     catch e
         stre = string(e)
         (err, line, column, pos) = xp_geterror(h.parser)
-        @DBG_PRINT ("$e, $err, $line, $column, $pos")
+        @DBG_PRINT("$e, $err, $line, $column, $pos")
         rethrow("$e, $err, $line, $column, $pos")
     finally
         if !suspended
@@ -267,7 +267,7 @@ function parse(txt::String,callbacks::XPCallbacks; data=nothing)
     catch e
         stre = string(e)
         (err, line, column, pos) = xp_geterror(h.parser)
-        @DBG_PRINT ("$e, $err, $line, $column, $pos")
+        @DBG_PRINT("$e, $err, $line, $column, $pos")
         rethrow("$e, $err, $line, $column, $pos")
 
     finally

--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -701,14 +701,14 @@ end
 isroot(pd::ETree) = (pd.parent == pd)
 
 immutable XPath{T<:String,
-                returntype <: Union(Vector{ETree},
+                returntype <: @compat(Union{Vector{ETree},
                       Vector{String},
                       Vector{Any},
                       Bool,
                       Number,
                       Int,
                       String,
-                      Any)}
+                      Any})}
     # an XPath filter is a series of XPath segments implemented as
     # (:cmd, data) pairs. For example,
     # "//A/..//*[2]" should be parsed as:
@@ -764,14 +764,14 @@ function xpath_combined_checked(pd1::XPath, pd2::XPath)
     return (filt, xp)
 end
 Base.|{T,S}(pd1::XPath{T}, pd2::XPath{S}) =
-    XPath{Union(T,S),Any}( xpath_combined_checked(pd1,pd2) )
+    XPath{@compat(Union{T,S}),Any}( xpath_combined_checked(pd1,pd2) )
 Base.|{T,S,ret1<:Vector,ret2<:Vector}(pd1::XPath{T,ret1}, pd2::XPath{S,ret2}) =
-    XPath{Union(T,S),Vector{Any}}( xpath_combined_checked(pd1,pd2) )
+    XPath{@compat(Union{T,S}),Vector{Any}}( xpath_combined_checked(pd1,pd2) )
 Base.|{T,S,ret<:Vector}(pd1::XPath{T,ret}, pd2::XPath{S,ret}) =
-    XPath{Union(T,S),ret}( xpath_combined_checked(pd1,pd2) )
+    XPath{@compat(Union{T,S}),ret}( xpath_combined_checked(pd1,pd2) )
 Base.|{T,S,ret}(pd1::XPath{T,ret}, pd2::XPath{S,ret}) =
-    XPath{Union(T,S),ret}( xpath_combined_checked(pd1,pd2) )
-#Base.(:*){T,S,ret}(pd::XPath{T,ret}, filters::S) = XPath{Union(T,S),ret}( ??? )
+    XPath{@compat(Union{T,S}),ret}( xpath_combined_checked(pd1,pd2) )
+#Base.(:*){T,S,ret}(pd::XPath{T,ret}, filters::S) = XPath{@compat(Union{T,S}),ret}( ??? )
 
 
 xpath_boolean(a::Bool) = a
@@ -1359,4 +1359,3 @@ getindex(pd::ETree,x::String) = xpath(pd,x)
 getindex(pd::ETree,x::XPath) = xpath(pd,x)
 getindex(pd::Vector{ETree},x::String) = xpath(pd, x)
 getindex(pd::Vector{ETree},x::XPath) = xpath(pd, x)
-

--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -27,8 +27,8 @@ const xpath_axes = Compat.@Dict(
     "self" => :self)
 
 const xpath_types = Compat.@Dict(
-    "comment" => (:comment,String),
-    "text" => (:text,String),
+    "comment" => (:comment,AbstractString),
+    "text" => (:text,AbstractString),
 #    "processing-instruction" => (:processing_instruction, ??),
     "node" => (:node,Any))
 
@@ -37,21 +37,21 @@ const xpath_functions = Compat.@Dict( # (name, min args, max args)
     "last" => (:last,0,0,Int),
     "position" => (:position,0,0,Int),
     "count" => (:count,1,1,Int),
-    "local-name" => (:local_name,0,1,String),
-    #"namespace-uri" => (:namespace_uri,0,1,String),
-    "name" => (:name,0,1,String),
+    "local-name" => (:local_name,0,1,AbstractString),
+    #"namespace-uri" => (:namespace_uri,0,1,AbstractString),
+    "name" => (:name,0,1,AbstractString),
 
     #string
-    "string" => (:string_fn,0,1,String),
-    "concat" => (:concat,2,typemax(Int),String),
+    "string" => (:string_fn,0,1,AbstractString),
+    "concat" => (:concat,2,typemax(Int),AbstractString),
     "starts-with" => (:startswith,2,2,Bool),
     "contains" => (:contains,2,2,Bool),
-    "substring-before" => (:substring_before,2,2,String),
-    "substring-after" => (:substring_after,2,2,String),
-    "substring" => (:substring,2,3,String),
+    "substring-before" => (:substring_before,2,2,AbstractString),
+    "substring-after" => (:substring_after,2,2,AbstractString),
+    "substring" => (:substring,2,3,AbstractString),
     "string-length" => (:string_length,0,1,Int),
-    "normalize-space" => (:normalize_space,0,1,String),
-    "translate" => (:translate,3,3,String),
+    "normalize-space" => (:normalize_space,0,1,AbstractString),
+    "translate" => (:translate,3,3,AbstractString),
 
     #boolean
     "boolean" => (:bool,1,1,Bool),
@@ -87,7 +87,7 @@ end
 
 const xpath_separators = Set(['+','(',')','[',']','<','>','!','=','|','/','*',','])
 
-function xpath_parse{T<:String}(xpath::T, ismacro=false)
+function xpath_parse{T<:AbstractString}(xpath::T, ismacro=false)
     k = start(xpath)
     k, parsed, returntype, has_last_fn = xpath_parse_expr(xpath, k, 0, ismacro)
     if !done(xpath,k)
@@ -96,7 +96,7 @@ function xpath_parse{T<:String}(xpath::T, ismacro=false)
     return parsed, returntype
 end
 
-#function xpath_parse_filters{T<:String}(xpath::T)
+#function xpath_parse_filters{T<:AbstractString}(xpath::T)
 #    k = consume_whitespace(xpath, start(xpath))
 #    c,k = next(xpath,k)
 #    if c != '['
@@ -117,7 +117,7 @@ macro xpath_parse(arg1, arg2)
     :(
         if $(esc(:ismacro))
             a2 = $(esc(arg2))
-            if !isa(a2,Expr) && !isa(a2,String)
+            if !isa(a2,Expr) && !isa(a2,AbstractString)
                 a2 = Expr(:quote,a2)
             end
             $(esc(:parsed)) = Expr(:call, :push!, $(esc(:parsed)), Expr(:tuple,Expr(:quote,$(esc(arg1))),a2))
@@ -130,7 +130,7 @@ macro xpath_fn(arg1, arg2)
     :(
         if $(esc(:ismacro))
             a2 = $(esc(arg2))
-            if !isa(a2,Expr) && !isa(a2,String)
+            if !isa(a2,Expr) && !isa(a2,AbstractString)
                 a2 = Expr(:quote,a2)
             end
             Expr(:tuple,Expr(:quote,$(esc(arg1))),a2)
@@ -140,7 +140,7 @@ macro xpath_fn(arg1, arg2)
     )
 end
 
-function xpath_parse{T<:String}(xpath::T, k, ismacro)
+function xpath_parse{T<:AbstractString}(xpath::T, k, ismacro)
     if ismacro
         parsed = :(Array(SymbolAny, 0))
     else
@@ -291,7 +291,7 @@ function xpath_parse{T<:String}(xpath::T, k, ismacro)
             else
                 @xpath_parse :attribute name
             end
-            returntype = String
+            returntype = AbstractString
         elseif name[1] == '$'
             @xpath_parse axis :element
             @xpath_parse :name Expr(:call, :string, esc(symbol(name[2:end])))
@@ -356,7 +356,7 @@ function xpath_parse{T<:String}(xpath::T, k, ismacro)
     return k, parsed, returntype
 end # function
 
-function xpath_parse_expr{T<:String}(xpath::T, k, precedence::Int, ismacro)
+function xpath_parse_expr{T<:AbstractString}(xpath::T, k, precedence::Int, ismacro)
     i = k = consume_whitespace(xpath, k)
     j = 0
     prevtokenspecial = true
@@ -484,7 +484,7 @@ function xpath_parse_expr{T<:String}(xpath::T, k, precedence::Int, ismacro)
             sexpr = xpath[next(xpath,i)[2]:j]
         end
         fn = @xpath_fn :string sexpr
-        returntype = String
+        returntype = AbstractString
     else
         if c == '('
             name = xpath[i:j]
@@ -498,7 +498,7 @@ function xpath_parse_expr{T<:String}(xpath::T, k, precedence::Int, ismacro)
                 fn_ = @xpath_fn :xpath_any fn_
             elseif typeseq(returntype, ETree)
                 fn_ = @xpath_fn :xpath fn_
-            elseif typeseq(returntype, String)
+            elseif typeseq(returntype, AbstractString)
                 if !ismacro && length(fn_) == 1 && fn_[1][1]::Symbol == :attribute
                     fn_ = fn_[1]
                 else
@@ -700,14 +700,14 @@ end
 
 isroot(pd::ETree) = (pd.parent == pd)
 
-immutable XPath{T<:String,
+immutable XPath{T<:AbstractString,
                 returntype <: @compat(Union{Vector{ETree},
-                      Vector{String},
+                      Vector{AbstractString},
                       Vector{Any},
                       Bool,
                       Number,
                       Int,
-                      String,
+                      AbstractString,
                       Any})}
     # an XPath filter is a series of XPath segments implemented as
     # (:cmd, data) pairs. For example,
@@ -727,7 +727,7 @@ type XPath_Collector
     end
 end
 
-xpath{T<:String}(filter::T) = (xp = xpath_parse(filter); XPath{T,xp[2]}(xp[1]))
+xpath{T<:AbstractString}(filter::T) = (xp = xpath_parse(filter); XPath{T,xp[2]}(xp[1]))
 
 function xpath{T,returntype}(pd::Vector, xp::XPath{T,Vector{returntype}})
     output = Array(returntype,0)
@@ -745,7 +745,7 @@ function xpath{T,returntype}(pd::Vector, xp::XPath{T,returntype})
     return output
 end
 xpath{T,returntype}(pd, xp::XPath{T,returntype}) = xpath_expr(pd, xp, xp.filter, 1, -1, returntype)::returntype
-xpath{T<:String}(pd, filter::T) = xpath(pd, xpath(filter))
+xpath{T<:AbstractString}(pd, filter::T) = xpath(pd, xpath(filter))
 
 function xpath_combined_checked(pd1::XPath, pd2::XPath)
     a1 = pd1.filter[1]
@@ -777,14 +777,14 @@ Base.|{T,S,ret}(pd1::XPath{T,ret}, pd2::XPath{S,ret}) =
 xpath_boolean(a::Bool) = a
 xpath_boolean(a::Int) = a != 0
 xpath_boolean(a::Float64) = a != 0 && !isnan(a)
-xpath_boolean(a::String) = !isempty(a)
+xpath_boolean(a::AbstractString) = !isempty(a)
 xpath_boolean(a::Vector) = !isempty(a)
 xpath_boolean(a::ETree) = true
 
 xpath_number(a::Bool) = a?1:0
 xpath_number(a::Int) = a
 xpath_number(a::Float64) = a
-xpath_number(a::String) = try parsefloat(a) catch ex NaN end
+xpath_number(a::AbstractString) = try parsefloat(a) catch ex NaN end
 xpath_number(a::Vector) = xpath_number(xpath_string(a))
 xpath_number(a::ETree) = xpath_number(xpath_string(a))
 
@@ -801,11 +801,11 @@ function xpath_string(a::Float64)
         return string(a)
     end
 end
-xpath_string(a::String) = a
+xpath_string(a::AbstractString) = a
 xpath_string(a::Vector) = length(a) == 0 ? "" : xpath_string(a[1])
 xpath_string(a::ETree) = string_value(a)
 
-function xpath_normalize(s::String)
+function xpath_normalize(s::AbstractString)
     normal = IOBuffer()
     space = false
     first = false
@@ -828,7 +828,7 @@ function xpath_normalize(s::String)
     takebuf_string(normal)
 end
 
-function xpath_translate(a::String,b::String,c::String)
+function xpath_translate(a::AbstractString,b::AbstractString,c::AbstractString)
     b = collect(b)
     c = collect(c)
     tr = IOBuffer()
@@ -843,26 +843,26 @@ function xpath_translate(a::String,b::String,c::String)
     takebuf_string(tr)
 end
 
-function xpath_expr{T<:String}(pd, xp::XPath{T}, filter::@compat(Tuple{Symbol,ANY}), position::Int, last::Int, output_hint::DataType)
+function xpath_expr{T<:AbstractString}(pd, xp::XPath{T}, filter::@compat(Tuple{Symbol,ANY}), position::Int, last::Int, output_hint::DataType)
     op = filter[1]::Symbol
     args = filter[2]
     if op == :attribute
         if !isa(pd, ETree)
-            return String[]
+            return AbstractString[]
         elseif isa(args, Nothing)
             return pd.attr
         else
             attr = get(pd.attr, args::T, nothing)
             if attr === nothing
-                return String[]
+                return AbstractString[]
             else
-                return String[attr]
+                return AbstractString[attr]
             end
         end
     elseif op == :number
         return args::Number
     elseif op == :string
-        return args::String
+        return args::AbstractString
     elseif op == :position
         assert(position > 0)
         return position
@@ -921,7 +921,7 @@ function xpath_expr{T<:String}(pd, xp::XPath{T}, filter::@compat(Tuple{Symbol,AN
                             a = xpath_number(a)
                         elseif isa(b, Bool)
                             a = xpath_boolean(a)
-                        elseif isa(b, String)
+                        elseif isa(b, AbstractString)
                             a = xpath_string(a)
                         else
                             assert(false)
@@ -931,7 +931,7 @@ function xpath_expr{T<:String}(pd, xp::XPath{T}, filter::@compat(Tuple{Symbol,AN
                             b = xpath_number(b)
                         elseif isa(a, Bool)
                             b = xpath_boolean(b)
-                        elseif isa(a, String)
+                        elseif isa(a, AbstractString)
                             b = xpath_string(b)
                         else
                             assert(false)
@@ -997,8 +997,8 @@ function xpath_expr{T<:String}(pd, xp::XPath{T}, filter::@compat(Tuple{Symbol,AN
     elseif op == :xpath_str
         if typeseq(output_hint, Bool)
             return xpath(pd, :node, xp, args::Vector{SymbolAny}, 1, Int[], 1, XPath_Collector(), Bool)::Bool
-        elseif typeseq(output_hint,Vector{String}) || typeseq(output_hint,Vector) || typeseq(output_hint,Any)
-            out = String[]
+        elseif typeseq(output_hint,Vector{AbstractString}) || typeseq(output_hint,Vector) || typeseq(output_hint,Any)
+            out = AbstractString[]
             xpath(pd, :node, xp, args::Vector{SymbolAny}, 1, Int[], 1, XPath_Collector(), out)
             return out
         else
@@ -1016,18 +1016,18 @@ function xpath_expr{T<:String}(pd, xp::XPath{T}, filter::@compat(Tuple{Symbol,AN
         end
     elseif op == :string_fn
         if length(args) == 0
-            a = xpath_string(pd)::String
+            a = xpath_string(pd)::AbstractString
         else
-            a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::String
+            a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::AbstractString
         end
         return a
     elseif op == :contains
-        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::String
-        b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::String
+        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::AbstractString
+        b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::AbstractString
         return !(isempty(search(a, b)))::Bool
     elseif op == :startswith
-        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::String
-        b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::String
+        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::AbstractString
+        b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::AbstractString
         return startswith(a,b)::Bool
     elseif op == :name
         if !isempty(args)
@@ -1035,37 +1035,37 @@ function xpath_expr{T<:String}(pd, xp::XPath{T}, filter::@compat(Tuple{Symbol,AN
             if isempty(a)
                 return ""
             else
-                return xpath_string(a[1])::String
+                return xpath_string(a[1])::AbstractString
             end
         else
-            return xpath_string(pd)::String
+            return xpath_string(pd)::AbstractString
         end
     elseif op == :concat
         a = IOBuffer()
         for arg = args
-            write(a, xpath_string(xpath_expr(pd, xp, arg::SymbolAny, position, last, Any))::String)
+            write(a, xpath_string(xpath_expr(pd, xp, arg::SymbolAny, position, last, Any))::AbstractString)
         end
-        return takebuf_string(a)::String
+        return takebuf_string(a)::AbstractString
     elseif op == :substring_before
-        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::String
-        b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::String
+        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::AbstractString
+        b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::AbstractString
         i = first(search(a,b))
         if i < 1
             return ""
         else
-            return a[1:prevind(a,i)]::String
+            return a[1:prevind(a,i)]::AbstractString
         end
     elseif op == :substring_after
-        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::String
-        b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::String
+        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::AbstractString
+        b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::AbstractString
         i = last(search(a,b))
         if i < 1
             return ""
         else
-            return a[nextind(a,i):end]::String
+            return a[nextind(a,i):end]::AbstractString
         end
     elseif op == :substring
-        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::String
+        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::AbstractString
         b = int(xpath_number(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any)))::Int
         if length(args) > 2
             c = int(xpath_number(xpath_expr(pd, xp, args[3]::SymbolAny, position, last, Any)))::Int
@@ -1075,23 +1075,23 @@ function xpath_expr{T<:String}(pd, xp::XPath{T}, filter::@compat(Tuple{Symbol,AN
         end
     elseif op == :string_length
         if isempty(args)
-            a = xpath_string(pd)::String
+            a = xpath_string(pd)::AbstractString
         else
-            a = xpath_string((xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any)))::String
+            a = xpath_string((xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any)))::AbstractString
         end
         return length(a)::Int
     elseif op == :normalize_space
         if isempty(args)
-            a = xpath_string(pd)::String
+            a = xpath_string(pd)::AbstractString
         else
-            a = xpath_string((xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any)))::String
+            a = xpath_string((xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any)))::AbstractString
         end
-        return xpath_normalize(a)::String
+        return xpath_normalize(a)::AbstractString
     elseif op == :translate
-        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::String
-        b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::String
-        c = xpath_string(xpath_expr(pd, xp, args[3]::SymbolAny, position, last, Any))::String
-        return xpath_translate(a,b,c)::String
+        a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::AbstractString
+        b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::AbstractString
+        c = xpath_string(xpath_expr(pd, xp, args[3]::SymbolAny, position, last, Any))::AbstractString
+        return xpath_translate(a,b,c)::AbstractString
     elseif op == :number_fn
         if isempty(args)
             return xpath_number(pd)::Number
@@ -1131,7 +1131,7 @@ function xpath_output(pd::ETree, output)
     end
     xpath_boolean(pd)::Bool
 end
-function xpath_output(string::String, output)
+function xpath_output(string::AbstractString, output)
     if isa(output,Vector)
         if !in(string, output)
             push!(output, string)
@@ -1139,7 +1139,7 @@ function xpath_output(string::String, output)
     end
     xpath_boolean(string)::Bool
 end
-function xpath_output(strings::Vector{String}, output)
+function xpath_output(strings::Vector{AbstractString}, output)
     if isa(output,Vector)
         for string in strings
             if !in(string, output)
@@ -1156,7 +1156,7 @@ end
 macro xpath_descendant(node)
     esc( :( iscounted |= xpath_descendant($(node), name::Symbol, xp, filter, index, position, position_index, collector, output) ) )
 end
-function xpath{T<:String}(pd, nodetype_filter::Symbol, xp::XPath{T}, filter::Vector{SymbolAny}, index::Int, position::Vector{Int}, position_index::Int, collector::XPath_Collector, output)
+function xpath{T<:AbstractString}(pd, nodetype_filter::Symbol, xp::XPath{T}, filter::Vector{SymbolAny}, index::Int, position::Vector{Int}, position_index::Int, collector::XPath_Collector, output)
     #return value is whether the node is "true" for the input to a boolean function
     #implements axes: child, descendant, parent, ancestor, self, root, descendant-or-self, ancestor-or-self
     #implements filters: name
@@ -1167,7 +1167,7 @@ function xpath{T<:String}(pd, nodetype_filter::Symbol, xp::XPath{T}, filter::Vec
     elseif nodetype_filter === :comment
         error("xpath comments are not currently saved as part of the xml")
     elseif nodetype_filter === :text
-        if !isa(pd, String)
+        if !isa(pd, AbstractString)
             return false
         end
     else
@@ -1225,7 +1225,7 @@ function xpath{T<:String}(pd, nodetype_filter::Symbol, xp::XPath{T}, filter::Vec
         iscounted = false
 
     elseif axis == :attribute
-        attrs = xpath_expr(pd, xp, filter[index-1]::SymbolAny, -1, -1, Vector{String})::Vector{String}
+        attrs = xpath_expr(pd, xp, filter[index-1]::SymbolAny, -1, -1, Vector{AbstractString})::Vector{AbstractString}
         name = :node
         @xpath attrs
 
@@ -1284,8 +1284,8 @@ function xpath{T<:String}(pd, nodetype_filter::Symbol, xp::XPath{T}, filter::Vec
             for child in pd.elements
                 if isa(child, ETree)
                     @xpath child::ETree
-                elseif isa(child, String)
-                    @xpath child::String
+                elseif isa(child, AbstractString)
+                    @xpath child::AbstractString
                 else
                     assert(false)
                 end
@@ -1346,8 +1346,8 @@ function xpath_descendant(pd::ETree, name::Symbol, xp::XPath, filter::Vector{Sym
         if isa(child, ETree)
             @xpath child::ETree
             @xpath_descendant child::ETree
-        elseif isa(child, String)
-            @xpath child::String
+        elseif isa(child, AbstractString)
+            @xpath child::AbstractString
         else
             assert(false)
         end
@@ -1355,7 +1355,7 @@ function xpath_descendant(pd::ETree, name::Symbol, xp::XPath, filter::Vector{Sym
     iscounted
 end
 
-getindex(pd::ETree,x::String) = xpath(pd,x)
+getindex(pd::ETree,x::AbstractString) = xpath(pd,x)
 getindex(pd::ETree,x::XPath) = xpath(pd,x)
-getindex(pd::Vector{ETree},x::String) = xpath(pd, x)
+getindex(pd::Vector{ETree},x::AbstractString) = xpath(pd, x)
 getindex(pd::Vector{ETree},x::XPath) = xpath(pd, x)

--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -649,7 +649,7 @@ function consume_function(xpath, k, name, ismacro)
     end
     fntype = get(xpath_functions, name, nothing)
     if fntype === nothing
-        return k, nothing, Nothing, false
+        return k, nothing, Void, false
     end
     minargs = fntype[2]::Int
     maxargs = fntype[3]::Int
@@ -849,7 +849,7 @@ function xpath_expr{T<:AbstractString}(pd, xp::XPath{T}, filter::@compat(Tuple{S
     if op == :attribute
         if !isa(pd, ETree)
             return AbstractString[]
-        elseif isa(args, Nothing)
+        elseif isa(args, Void)
             return pd.attr
         else
             attr = get(pd.attr, args::T, nothing)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ const DATADIR = joinpath(dirname(@__FILE__), "data")
 pd = xp_parse(open(readall, joinpath(DATADIR,"t_s1.txt")))
 @test isa(pd, ETree)
 println("PASSED 1")
-println(methods(find))
+
 ret = find(pd, "/ListBucketResult")
 @test isa(ret, Array)
 @test length(ret) == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,69 +7,69 @@ pd = xp_parse(open(readall, joinpath(DATADIR,"t_s1.txt")))
 @test isa(pd, ETree)
 println("PASSED 1")
 
-ret = find(pd, "/ListBucketResult")
+ret = LibExpat.find(pd, "/ListBucketResult")
 @test isa(ret, Array)
 @test length(ret) == 1
 @test isa(ret[1], ETree)
 println("PASSED 1.1")
 
-ret = find(pd, "/ListBucketResult/Name")
+ret = LibExpat.find(pd, "/ListBucketResult/Name")
 @test isa(ret, Array)
 println("PASSED 2")
 
-ret = find(pd, "/ListBucketResult/Name#string")
+ret = LibExpat.find(pd, "/ListBucketResult/Name#string")
 @test ret == "bucket"
 println("PASSED 3")
 
-ret = find(pd, "/ListBucketResult/Contents")
+ret = LibExpat.find(pd, "/ListBucketResult/Contents")
 @test isa(ret, Array)
 @test length(ret) == 2
 @test isa(ret[1], ETree)
 @test isa(ret[2], ETree)
 println("PASSED 4")
 
-@test_throws ErrorException find(pd, "/ListBucketResult/Contents#string")
+@test_throws ErrorException LibExpat.find(pd, "/ListBucketResult/Contents#string")
 println("PASSED 5")
 
-ret = split(strip(find(pd, "/ListBucketResult/Contents[1]#string")),'\n')
+ret = split(strip(LibExpat.find(pd, "/ListBucketResult/Contents[1]#string")),'\n')
 @test ret[1] == "C1C1C1"
 println("PASSED 6")
 
-@test (find(pd, "/ListBucketResult/Contents[1]#string") == find(pd, "Contents[1]#string"))
+@test (LibExpat.find(pd, "/ListBucketResult/Contents[1]#string") == LibExpat.find(pd, "Contents[1]#string"))
 println("PASSED 6.1")
 
-ret = split(strip(find(pd, "/ListBucketResult/Contents[2]#string")),'\n')
+ret = split(strip(LibExpat.find(pd, "/ListBucketResult/Contents[2]#string")),'\n')
 @test ret[1] == "C2C2C2"
 println("PASSED 7")
 
-ret = find(pd, "/ListBucketResult/Contents[1]/Owner/ID")
+ret = LibExpat.find(pd, "/ListBucketResult/Contents[1]/Owner/ID")
 @test isa(ret, Array)
 @test length(ret) == 1
 @test isa(ret[1], ETree)
 println("PASSED 8")
 
-ret = find(pd, "/ListBucketResult/Contents[1]/Owner/ID#string")
+ret = LibExpat.find(pd, "/ListBucketResult/Contents[1]/Owner/ID#string")
 @test ret == "11111111111111111111111111111111"
 println("PASSED 9")
 
-ret = find(pd, "/ListBucketResult/Contents[1]/Owner/ID{idk}")
+ret = LibExpat.find(pd, "/ListBucketResult/Contents[1]/Owner/ID{idk}")
 @test ret == "IDKV1"
 println("PASSED 10")
 
-ret = find(pd, "/ListBucketResult/Contents[2]/Owner/ID{idk}")
+ret = LibExpat.find(pd, "/ListBucketResult/Contents[2]/Owner/ID{idk}")
 @test ret == "IDKV2"
 println("PASSED 11")
 
-@test (find(pd, "/ListBucketResult/Contents[2]/Owner/ID{idk}") == find(pd, "Contents[2]/Owner/ID{idk}"))
+@test (LibExpat.find(pd, "/ListBucketResult/Contents[2]/Owner/ID{idk}") == LibExpat.find(pd, "Contents[2]/Owner/ID{idk}"))
 println("PASSED 11.1")
 
-@test (find(pd, "/I/Do/NOT/Exist") == [])
+@test (LibExpat.find(pd, "/I/Do/NOT/Exist") == [])
 println("PASSED 12")
 
-@test (find(pd, "/I/Do/NOT/Exist[1]") == nothing)
+@test (LibExpat.find(pd, "/I/Do/NOT/Exist[1]") == nothing)
 println("PASSED 12.1")
 
-@test (find(pd, "/ListBucketResult/Contents[2]/Owner/JUNK#string") == nothing)
+@test (LibExpat.find(pd, "/ListBucketResult/Contents[2]/Owner/JUNK#string") == nothing)
 println("PASSED 12.2")
 
 pd = xp_parse(open(readall, joinpath(DATADIR,"utf8.xml")))
@@ -79,7 +79,7 @@ println("PASSED 13")
 
 pd = xp_parse(open(readall, joinpath(DATADIR,"wiki.xml")))
 @test isa(pd, ParsedData)
-ret = find(pd, "/page/revision/id#string")
+ret = LibExpat.find(pd, "/page/revision/id#string")
 @test ret == "557462847"
 println("PASSED 14")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ const DATADIR = joinpath(dirname(@__FILE__), "data")
 pd = xp_parse(open(readall, joinpath(DATADIR,"t_s1.txt")))
 @test isa(pd, ETree)
 println("PASSED 1")
-
+println(methods(find))
 ret = find(pd, "/ListBucketResult")
 @test isa(ret, Array)
 @test length(ret) == 1


### PR DESCRIPTION
On Julia 0.4-RC2, with the new deprecation warnings, I got stuck in a loop of deprecation warnings, regarding the Union{} deprecation. This new deprecation was not included yet in #32, so I added it to those commits. Also removes all other warnings on 0.4-RC2.

How exactly this loop can happen I do not understand, but this solves it. I'm likely not the only one with this problem, but it's likely WinRPM/Windows related, see https://groups.google.com/forum/#!topic/julia-users/OPugaioAGUU

