### PR TITLE
use qualified LibExpat.find in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Has only three relevant APIs
 
 - ```xp_parse(s::String)``` returns a parsed object of type ```ETree``` (used to be called ```ParsedData```).
 
-- ```find(pd::ETree, element_path::String)``` is used to search for elements within the parsed data object as returned by ```xp_parse```
+- ```LibExpat.find(pd::ETree, element_path::String)``` is used to search for elements within the parsed data object as returned by ```xp_parse```
 
 - ```(pd::ETree)[xpath::String]``` or ```xpath(pd::ETree, xpath::String)``` is also used to search for elements within the parsed
 data object as returned by ```xp_parse```, but using a subset of the xpath specification
@@ -50,7 +50,7 @@ If only one sub-element exists, the index is assumed to be 1 and may be omitted.
 - If ```element_path``` does NOT start with a ```/``` then the search starts with the children of the root pd (the first argument)
 
 
-You can also navigate the returned ETree object directly, i.e., without using ```find```.
+You can also navigate the returned ETree object directly, i.e., without using ```LibExpat.find```.
 The relevant members of ETree are:
 
 ```
@@ -103,4 +103,3 @@ If your data is too large to fit into memory, as an alternative you can use `xp_
 IJulia Demonstration Notebook
 =============================
 [LibExpat IJulia Demo ](http://nbviewer.ipython.org/urls/raw.github.com/amitmurthy/LibExpat.jl/master/libexpat_test.ipynb)
-

--- a/libexpat_test.ipynb
+++ b/libexpat_test.ipynb
@@ -42,14 +42,21 @@
        "output_type": "pyout",
        "prompt_number": 161,
        "text": [
-        "7-element Array{Symbol,1}:\n",
-        " :ParsedData\n",
-        " :ETree     \n",
-        " :LibExpat  \n",
-        " :@xpath_str\n",
-        " :find      \n",
-        " :xpath     \n",
-        " :xp_parse  "
+       "14-element Array{Symbol,1}:\n",
+       " :LibExpat           \n",
+       " :XPStreamHandler    \n",
+       " :free               \n",
+       " :xpath              \n",
+       " :pause              \n",
+       " :ETree              \n",
+       " symbol(\"@xpath_str\")\n",
+       " :ParsedData         \n",
+       " :stop               \n",
+       " :resume             \n",
+       " :parse              \n",
+       " :XPCallbacks        \n",
+       " :parsefile          \n",
+       " :xp_parse           "
        ]
       }
      ],
@@ -100,7 +107,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "### Use find(et, element_path) to return an array of ETree objects matching an element path string \n",
+      "### Use LibExpat.find(et, element_path) to return an array of ETree objects matching an element path string \n",
       "\n",
       "The LibExpat.jl README describes the format of element_path.\n"
      ]
@@ -367,7 +374,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "tds = find(et, \"/div/table//table//td\")"
+      "tds = LibExpat.find(et, \"/div/table//table//td\")"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
In #37 I removed the `find` export. I should've directly fixed these docs, but here it is.