### PR TITLE
Fix hygiene bug

### DIFF
--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -122,7 +122,7 @@ macro xpath_parse(arg1, arg2)
             end
             $(esc(:parsed)) = Expr(:call, :push!, $(esc(:parsed)), Expr(:tuple,Expr(:quote,$(esc(arg1))),a2))
         else
-            push!($(esc(:parsed))::Vector{SymbolAny}, ($(arg1),$(arg2)))
+            push!($(esc(:parsed))::Vector{SymbolAny}, ($(esc(arg1)),$(esc(arg2))))
         end
     )
 end
@@ -135,7 +135,7 @@ macro xpath_fn(arg1, arg2)
             end
             Expr(:tuple,Expr(:quote,$(esc(arg1))),a2)
         else
-            ($(arg1),$(arg2))
+            ($(esc(arg1)),$(esc(arg2)))
         end
     )
 end


### PR DESCRIPTION
Doesn't fix all test errors but helps fix a macro hygiene bug

```julia

julia> Pkg.test("LibExpat")
INFO: Testing LibExpat
PASSED 1
PASSED 1.1
PASSED 2
PASSED 3
PASSED 4
PASSED 5
PASSED 6
PASSED 6.1
PASSED 7
PASSED 8
PASSED 9
PASSED 10
PASSED 11
PASSED 11.1
PASSED 12
PASSED 12.1
PASSED 12.2
PASSED 13
PASSED 14
ERROR: LoadError: "MethodError(#1,(LibExpat.XPStreamHandler{Void}(LibExpat.XPCallbacks(LibExpat.#1,LibExpat.#2,LibExpat.#3,LibExpat.#4,LibExpat.#5,LibExpat.#6,#1,#3,LibExpat.#9,LibExpat.#10),Ptr{Void} @0x0000000017e9ab00,nothing),\"test\",Dict{AbstractString,AbstractString}(Pair{AbstractString,AbstractString}(\"id\",\"someid\"))),0x00000000000050c1), , 0, 0, 0"
Stacktrace:
 [1] streaming_start_element(::Ptr{Void}, ::Ptr{UInt8}, ::Ptr{Ptr{UInt8}}) at C:\Users\Mus\.julia\v0.6\LibExpat\src\streaming.jl:75
 [2] #parse#22(::Void, ::Function, ::String, ::LibExpat.XPCallbacks) at C:\Users\Mus\.julia\v0.6\LibExpat\src\streaming.jl:255
 [3] parse(::String, ::LibExpat.XPCallbacks) at C:\Users\Mus\.julia\v0.6\LibExpat\src\streaming.jl:251
 [4] include_from_node1(::String) at .\loading.jl:532
 [5] include(::String) at .\sysimg.jl:14
 [6] process_options(::Base.JLOptions) at .\client.jl:298
 [7] _start() at .\client.jl:364
while loading C:\Users\Mus\.julia\v0.6\LibExpat\test\runtests.jl, in expression starting on line 109
=====================================================================[ ERROR: LibExpat ]=====================================================================

failed process: Process(`'C:\Julia\Julia-0.6-latest\bin\julia' -Cx86-64 '-JC:\Julia\Julia-0.6-latest\lib\julia\sys.dll' --compile=yes --depwarn=yes --check-bounds=yes --code-coverage=none --color=yes --compilecache=yes 'C:\Users\Mus\.julia\v0.6\LibExpat\test\runtests.jl'`, ProcessExited(1)) [1]

=============================================================================================================================================================ERROR: LibExpat had test errors
Stacktrace:
 [1] #test#61(::Bool, ::Function, ::Array{AbstractString,1}) at .\pkg\entry.jl:754
 [2] (::Base.Pkg.Entry.#kw##test)(::Array{Any,1}, ::Base.Pkg.Entry.#test, ::Array{AbstractString,1}) at .\<missing>:0
 [3] (::Base.Pkg.Dir.##2#3{Array{Any,1},Base.Pkg.Entry.#test,Tuple{Array{AbstractString,1}}})() at .\pkg\dir.jl:31
 [4] cd(::Base.Pkg.Dir.##2#3{Array{Any,1},Base.Pkg.Entry.#test,Tuple{Array{AbstractString,1}}}, ::String) at .\file.jl:58
 [5] #cd#1(::Array{Any,1}, ::Function, ::Function, ::Array{AbstractString,1}, ::Vararg{Array{AbstractString,1},N}) at .\pkg\dir.jl:31
 [6] (::Base.Pkg.Dir.#kw##cd)(::Array{Any,1}, ::Base.Pkg.Dir.#cd, ::Function, ::Array{AbstractString,1}, ::Vararg{Array{AbstractString,1},N}) at .\<missing>:0
 [7] #test#3(::Bool, ::Function, ::String, ::Vararg{String,N}) at .\pkg\pkg.jl:259
 [8] test(::String, ::Vararg{String,N}) at .\pkg\pkg.jl:259
```
