### PR TITLE
Remove unnecessary compat  macro

### DIFF
--- a/src/LibExpat.jl
+++ b/src/LibExpat.jl
@@ -1,9 +1,9 @@
 module LibExpat
 
 using Compat
+using Compat: String, unsafe_string
+
 import Base: getindex, show, parse
-import Compat.String
-import Compat.unsafe_string
 
 if is_windows() 
     const libexpat = "libexpat-1"
@@ -34,7 +34,7 @@ type ETree
     # Dict of tag attributes as name-value pairs
     attr::Dict{AbstractString,AbstractString}
     # List of child elements.
-    elements::Vector{@compat(Union{ETree,AbstractString})}
+    elements::Vector{Union{ETree,AbstractString}}
     parent::ETree
 
     ETree() = ETree("")
@@ -42,7 +42,7 @@ type ETree
         pd=new(
             name,
             Dict{AbstractString, AbstractString}(),
-            @compat(Union{ETree,AbstractString})[])
+            Union{ETree,AbstractString}[])
         pd.parent=pd
         pd
     end
@@ -83,7 +83,7 @@ end
 
 
 type XPHandle
-  parser::@compat(Union{XML_Parser,Void})
+  parser::Union{XML_Parser,Void}
   pdata::ETree
   in_cdata::Bool
 
@@ -117,7 +117,7 @@ function xp_make_parser(sep='\0')
 end
 
 
-function xp_geterror(p::@compat(Union{XML_Parser,Void}))
+function xp_geterror(p::Union{XML_Parser,Void})
     ec = XML_GetErrorCode(p)
 
     if ec != 0
@@ -166,7 +166,7 @@ cb_end_cdata = cfunction(end_cdata, Void, (Ptr{Void},))
 function cdata(p_xph::Ptr{Void}, s::Ptr{UInt8}, len::Cint)
     xph = unsafe_pointer_to_objref(p_xph)::XPHandle
 
-    txt = unsafe_string(s, @compat(Int(len)))
+    txt = unsafe_string(s, Int(len))
     push!(xph.pdata.elements, txt)
 
     @DBG_PRINT("Found CData : " * txt)
@@ -320,7 +320,7 @@ function find{T<:AbstractString}(pd::ETree, path::T)
         end
     end
 
-    xp= Array(@compat(Tuple{Symbol,Any}),0)
+    xp= Array(Tuple{Symbol,Any},0)
     if path[1] == '/'
         # This will treat the incoming pd as the root of the tree
         push!(xp, (:root,:element))

--- a/src/lX_common_h.jl
+++ b/src/lX_common_h.jl
@@ -1,5 +1,5 @@
 macro c(ret_type, func, arg_types, lib)
-  local args_in = Any[@compat Symbol(string('a',x)) for x in 1:length(arg_types.args) ]
+  local args_in = Any[Symbol(string('a',x)) for x in 1:length(arg_types.args)]
   quote
     $(esc(func))($(args_in...)) = ccall( ($(string(func)), $(esc(lib))), $(esc(ret_type)), $(esc(arg_types)), $(args_in...) )
   end

--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -57,7 +57,7 @@ cb_streaming_end_cdata = cfunction(streaming_end_cdata, Void, (Ptr{Void},))
 function streaming_cdata(p_cbs::Ptr{Void}, s::Ptr{UInt8}, len::Cint)
     h = unsafe_pointer_to_objref(p_cbs)::XPStreamHandler
 
-    txt = unsafe_string(s, @compat(Int(len)))
+    txt = unsafe_string(s, Int(len))
 
     @DBG_PRINT("Found CData : " * txt)
     h.cbs.character_data(h, txt)

--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -67,7 +67,7 @@ const xpath_functions = Compat.@Dict( # (name, min args, max args)
     "ceiling" => (:ceiling,1,1,Int),
     "round" => (:round,1,1,Float64))
 
-typealias SymbolAny @compat(Tuple{Symbol,Any})
+typealias SymbolAny Tuple{Symbol,Any}
 
 macro xpath_str(xpath)
     xp, returntype = xpath_parse(xpath, true)
@@ -294,7 +294,7 @@ function xpath_parse{T<:AbstractString}(xpath::T, k, ismacro)
             returntype = AbstractString
         elseif name[1] == '$'
             @xpath_parse axis :element
-            @xpath_parse :name Expr(:call, :string, esc(@compat(Symbol(name[2:end]))))
+            @xpath_parse :name Expr(:call, :string, esc(Symbol(name[2:end])))
         else
             @xpath_parse axis :element
             if name != "*"
@@ -439,9 +439,7 @@ function xpath_parse_expr{T<:AbstractString}(xpath::T, k, precedence::Int, ismac
                         write(str,c)
                         continue
                     elseif !isalnum(c) && c!='_' && c!='!'
-                        push!(sexpr.args, Expr(:call,:string,esc(
-                            @compat(Symbol(String(take!(str))))
-                        )))
+                        push!(sexpr.args, Expr(:call,:string,esc(Symbol(String(take!(str))))))
                         var = false
                         if parenvar
                             if c != ')' # we aren't interested in writing a general purpose string parser
@@ -473,9 +471,7 @@ function xpath_parse_expr{T<:AbstractString}(xpath::T, k, precedence::Int, ismac
             end
             if var == true
                 (nb_available(str) != 0 && !parenvar) || error("invalid interpolation syntax at $j")
-                push!(sexpr.args, Expr(:call,:string,esc(
-                    @compat(Symbol(String(take!(str))))
-                )))
+                push!(sexpr.args, Expr(:call,:string,esc(Symbol(String(take!(str))))))
             else
                 nb_available(str) != 0 && push!(sexpr.args, String(take!(str)))
             end
@@ -705,14 +701,14 @@ end
 isroot(pd::ETree) = (pd.parent == pd)
 
 immutable XPath{T<:AbstractString,
-                returntype <: @compat(Union{Vector{ETree},
+                returntype <: Union{Vector{ETree},
                       Vector{AbstractString},
                       Vector{Any},
                       Bool,
                       Number,
                       Int,
                       AbstractString,
-                      Any})}
+                      Any}}
     # an XPath filter is a series of XPath segments implemented as
     # (:cmd, data) pairs. For example,
     # "//A/..//*[2]" should be parsed as:
@@ -768,14 +764,14 @@ function xpath_combined_checked(pd1::XPath, pd2::XPath)
     return (filt, xp)
 end
 |{T,S}(pd1::XPath{T}, pd2::XPath{S}) =
-    XPath{@compat(Union{T,S}),Any}( xpath_combined_checked(pd1,pd2) )
+    XPath{Union{T,S},Any}( xpath_combined_checked(pd1,pd2) )
 |{T,S,ret1<:Vector,ret2<:Vector}(pd1::XPath{T,ret1}, pd2::XPath{S,ret2}) =
-    XPath{@compat(Union{T,S}),Vector{Any}}( xpath_combined_checked(pd1,pd2) )
+    XPath{Union{T,S},Vector{Any}}( xpath_combined_checked(pd1,pd2) )
 |{T,S,ret<:Vector}(pd1::XPath{T,ret}, pd2::XPath{S,ret}) =
-    XPath{@compat(Union{T,S}),ret}( xpath_combined_checked(pd1,pd2) )
+    XPath{Union{T,S},ret}( xpath_combined_checked(pd1,pd2) )
 |{T,S,ret}(pd1::XPath{T,ret}, pd2::XPath{S,ret}) =
-    XPath{@compat(Union{T,S}),ret}( xpath_combined_checked(pd1,pd2) )
-#*{T,S,ret}(pd::XPath{T,ret}, filters::S) = XPath{@compat(Union{T,S}),ret}( ??? )
+    XPath{Union{T,S},ret}( xpath_combined_checked(pd1,pd2) )
+#*{T,S,ret}(pd::XPath{T,ret}, filters::S) = XPath{Union{T,S},ret}( ??? )
 
 
 xpath_boolean(a::Bool) = a
@@ -847,7 +843,7 @@ function xpath_translate(a::AbstractString,b::AbstractString,c::AbstractString)
     String(take!(tr))
 end
 
-function xpath_expr{T<:AbstractString}(pd, xp::XPath{T}, filter::@compat(Tuple{Symbol,ANY}), position::Int, last::Int, output_hint::DataType)
+function xpath_expr{T<:AbstractString}(pd, xp::XPath{T}, filter::Tuple{Symbol,ANY}, position::Int, last::Int, output_hint::DataType)
     op = filter[1]::Symbol
     args = filter[2]
     if op == :attribute


### PR DESCRIPTION
I think these were needed for 0.3? but the tests pass on 0.4 and 0.5 so I think we can remove them now.