### PR TITLE
Fix another macro hygiene bug and debug flags

### DIFF
--- a/src/LibExpat.jl
+++ b/src/LibExpat.jl
@@ -10,13 +10,17 @@ if is_windows()
 elseif is_unix() 
     const libexpat = "libexpat"
 end
+
 include("lX_common_h.jl")
 include("lX_defines_h.jl")
 include("lX_expat_h.jl")
 #include("lX_exports_h.jl")
 
 export ETree, xp_parse, xpath, @xpath_str
-export ParsedData # deprecated
+
+# streaming
+export XPCallbacks, XPStreamHandler,
+       parse, stop, pause, resume, free, parsefile
 
 type ETree
     # XML Tag
@@ -37,7 +41,8 @@ type ETree
         pd
     end
 end
-typealias ParsedData ETree
+
+Base.@deprecate_binding ParsedData ETree
 
 function show(io::IO, pd::ETree)
     print(io,'<',pd.name)
@@ -376,7 +381,5 @@ end
 include("xpath.jl")
 
 include("streaming.jl")
-export XPCallbacks, XPStreamHandler
-export parse, stop, pause, resume, free, parsefile
 
 end

--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -35,7 +35,6 @@ XPCallbacks() = XPCallbacks(
 
 
 function streaming_start_cdata(p_cbs::Ptr{Void})
-    @DBG_PRINT("Found StartCdata")
     h = unsafe_pointer_to_objref(p_cbs)::XPStreamHandler
 
     h.cbs.start_cdata(h)
@@ -45,7 +44,6 @@ cb_streaming_start_cdata = cfunction(streaming_start_cdata, Void, (Ptr{Void},))
 
 
 function streaming_end_cdata(p_cbs::Ptr{Void})
-    @DBG_PRINT("Found EndCdata")
     h = unsafe_pointer_to_objref(p_cbs)::XPStreamHandler
 
     h.cbs.end_cdata(h)
@@ -59,7 +57,6 @@ function streaming_cdata(p_cbs::Ptr{Void}, s::Ptr{UInt8}, len::Cint)
 
     txt = unsafe_string(s, Int(len))
 
-    @DBG_PRINT("Found CData : " * txt)
     h.cbs.character_data(h, txt)
 
     return
@@ -82,7 +79,6 @@ cb_streaming_start_element = cfunction(streaming_start_element, Void, (Ptr{Void}
 function streaming_end_element(p_h::Ptr{Void}, name::Ptr{UInt8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt::AbstractString = unsafe_string(name)
-    @DBG_PRINT("End element: $txt")
 
     h.cbs.end_element(h, txt)
 
@@ -93,7 +89,6 @@ cb_streaming_end_element = cfunction(streaming_end_element, Void, (Ptr{Void},Ptr
 function streaming_comment(p_h::Ptr{Void}, data::Ptr{UInt8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt = unsafe_string(data)
-    @DBG_PRINT("Found comment : " * txt)
 
     h.cbs.comment(h, txt)
 
@@ -105,7 +100,6 @@ cb_streaming_comment = cfunction(streaming_comment, Void, (Ptr{Void},Ptr{UInt8})
 function streaming_default(p_h::Ptr{Void}, data::Ptr{UInt8}, len::Cint)
     xph = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt = unsafe_string(data)
-    @DBG_PRINT("Default : " * txt)
 
     h.cbs.default(h, txt)
 
@@ -117,7 +111,6 @@ cb_streaming_default = cfunction(streaming_default, Void, (Ptr{Void},Ptr{UInt8},
 function streaming_default_expand(p_h::Ptr{Void}, data::Ptr{UInt8}, len::Cint)
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt = unsafe_string(data)
-    @DBG_PRINT("Default Expand : " * txt)
 
     h.cbs.default_expand(h, txt)
 
@@ -130,7 +123,6 @@ function streaming_start_namespace(p_h::Ptr{Void}, prefix::Ptr{UInt8}, uri::Ptr{
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     prefix = unsafe_string(prefix)
     uri = unsafe_string(uri)
-    @DBG_PRINT("start namespace prefix : $prefix, uri: $uri")
 
     h.cbs.start_namespace(h, prefix, uri)
 
@@ -142,7 +134,6 @@ cb_streaming_start_namespace = cfunction(streaming_start_namespace, Void, (Ptr{V
 function streaming_end_namespace(p_h::Ptr{Void}, prefix::Ptr{UInt8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     prefix = unsafe_string(prefix)
-    @DBG_PRINT("end namespace prefix : $prefix")
 
     h.cbs.end_namespace(h, prefix)
 
@@ -237,7 +228,6 @@ function parsefile(filename::AbstractString,callbacks::XPCallbacks; bufferlines=
     catch e
         stre = string(e)
         (err, line, column, pos) = xp_geterror(h.parser)
-        @DBG_PRINT("$e, $err, $line, $column, $pos")
         rethrow("$e, $err, $line, $column, $pos")
     finally
         if !suspended
@@ -264,7 +254,6 @@ function parse(txt::AbstractString,callbacks::XPCallbacks; data=nothing)
     catch e
         stre = string(e)
         (err, line, column, pos) = xp_geterror(h.parser)
-        @DBG_PRINT("$e, $err, $line, $column, $pos")
         rethrow("$e, $err, $line, $column, $pos")
 
     finally

--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -49,7 +49,7 @@ function streaming_end_cdata(p_cbs::Ptr{Void})
     h = unsafe_pointer_to_objref(p_cbs)::XPStreamHandler
 
     h.cbs.end_cdata(h)
-    return;
+    return
 end
 cb_streaming_end_cdata = cfunction(streaming_end_cdata, Void, (Ptr{Void},))
 
@@ -62,7 +62,7 @@ function streaming_cdata(p_cbs::Ptr{Void}, s::Ptr{UInt8}, len::Cint)
     @DBG_PRINT("Found CData : " * txt)
     h.cbs.character_data(h, txt)
 
-    return;
+    return
 end
 cb_streaming_cdata = cfunction(streaming_cdata, Void, (Ptr{Void},Ptr{UInt8}, Cint))
 
@@ -82,7 +82,7 @@ cb_streaming_start_element = cfunction(streaming_start_element, Void, (Ptr{Void}
 function streaming_end_element(p_h::Ptr{Void}, name::Ptr{UInt8})
     h = unsafe_pointer_to_objref(p_h)::XPStreamHandler
     txt::AbstractString = unsafe_string(name)
-    @DBG_PRINT("End element: $txt, current element: $(xph.pdata.name) ")
+    @DBG_PRINT("End element: $txt")
 
     h.cbs.end_element(h, txt)
 
@@ -109,7 +109,7 @@ function streaming_default(p_h::Ptr{Void}, data::Ptr{UInt8}, len::Cint)
 
     h.cbs.default(h, txt)
 
-    return;
+    return
 end
 cb_streaming_default = cfunction(streaming_default, Void, (Ptr{Void},Ptr{UInt8}, Cint))
 
@@ -121,7 +121,7 @@ function streaming_default_expand(p_h::Ptr{Void}, data::Ptr{UInt8}, len::Cint)
 
     h.cbs.default_expand(h, txt)
 
-    return;
+    return
 end
 cb_streaming_default_expand = cfunction(streaming_default_expand, Void, (Ptr{Void},Ptr{UInt8}, Cint))
 
@@ -134,7 +134,7 @@ function streaming_start_namespace(p_h::Ptr{Void}, prefix::Ptr{UInt8}, uri::Ptr{
 
     h.cbs.start_namespace(h, prefix, uri)
 
-    return;
+    return
 end
 cb_streaming_start_namespace = cfunction(streaming_start_namespace, Void, (Ptr{Void},Ptr{UInt8}, Ptr{UInt8}))
 
@@ -146,7 +146,7 @@ function streaming_end_namespace(p_h::Ptr{Void}, prefix::Ptr{UInt8})
 
     h.cbs.end_namespace(h, prefix)
 
-    return;
+    return
 end
 cb_streaming_end_namespace = cfunction(streaming_end_namespace, Void, (Ptr{Void},Ptr{UInt8}))
 
@@ -215,7 +215,7 @@ function parsefile(filename::AbstractString,callbacks::XPCallbacks; bufferlines=
                 write(io, readline(file))
                 i += 1
             end
-            txt = Compat.String(io)
+            txt = String(io)
             rc = XML_Parse(h.parser, txt, sizeof(txt), 0)
             if (rc != XML_STATUS_OK) && (XML_GetErrorCode(h.parser) != XML_ERROR_ABORTED)
                 # Do not fail if the user aborted the parsing

--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -9,9 +9,8 @@
 # XPath Spec: http://www.w3.org/TR/xpath/
 
 import Base: typeseq, |
-import Compat
 
-const xpath_axes = Compat.@Dict(
+const xpath_axes = Dict(
     "ancestor" => :ancestor,
     "ancestor-or-self" => :ancestor_or_self,
     "attribute" => :attribute,
@@ -26,13 +25,13 @@ const xpath_axes = Compat.@Dict(
     "preceding-sibling" => :preceding_sibling,
     "self" => :self)
 
-const xpath_types = Compat.@Dict(
+const xpath_types = Dict(
     "comment" => (:comment,AbstractString),
     "text" => (:text,AbstractString),
 #    "processing-instruction" => (:processing_instruction, ??),
     "node" => (:node,Any))
 
-const xpath_functions = Compat.@Dict( # (name, min args, max args)
+const xpath_functions = Dict( # (name, min args, max args)
     #node-set
     "last" => (:last,0,0,Int),
     "position" => (:position,0,0,Int),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,12 +74,12 @@ println("PASSED 12.1")
 println("PASSED 12.2")
 
 pd = xp_parse(open(readstring, joinpath(DATADIR,"utf8.xml")))
-@test isa(pd, ParsedData)
+@test isa(pd, ETree)
 println("PASSED 13")
 
 
 pd = xp_parse(open(readstring, joinpath(DATADIR,"wiki.xml")))
-@test isa(pd, ParsedData)
+@test isa(pd, ETree)
 ret = LibExpat.find(pd, "/page/revision/id#string")
 @test ret == "557462847"
 println("PASSED 14")


### PR DESCRIPTION
So previously this package wouldn't run with `DEBUG = true` on 0.5  and 0.6 (also due to another hygiene bug)